### PR TITLE
refactored calcloud commands for current caldp calling sequence

### DIFF
--- a/calcloud/plan.py
+++ b/calcloud/plan.py
@@ -62,7 +62,7 @@ STIS: 99 per mem 1.0 gb
 #
 # NOTE:  for the initial prototype,  the job definition is named calcloud-hst-caldp-job-definition
 JobResources = namedtuple("JobResources", [
-    "ipppssoot", "instrument", "job_name", "s3_output_uri", "vcpus", "memory", "max_seconds"
+    "ipppssoot", "instrument", "job_name", "s3_output_uri", "input_path", "crds_config", "vcpus", "memory", "max_seconds"
     ])
 
 # Conceptually the resource requirements defined here could be obtained from a database that records real-world
@@ -90,7 +90,9 @@ def get_resources(ipppssoot, output_bucket, batch_name):
     s3_output_uri = f"{output_bucket}/{batch_name}"
     instr = hst.get_instrument(ipppssoot)
     job_name = batch_name + "-" + ipppssoot
-    return JobResources(*(ipppssoot, instr, job_name, s3_output_uri,) + JOB_INFO[instr])
+    input_path = "astroquery:"
+    crds_config = "caldp-config-offsite"
+    return JobResources(*(ipppssoot, instr, job_name, s3_output_uri, input_path, crds_config) + JOB_INFO[instr])
 
 def get_resources_tuples(ipppssoots, output_bucket="s3://calcloud-hst-pipeline-outputs", batch_name="batch"):
     """

--- a/calcloud/submit.py
+++ b/calcloud/submit.py
@@ -19,8 +19,10 @@ def submit_job(plan_tuple):
             "memory": info.memory,
             "command": [
                 info.command,
+                info.ipppssoot,
+                info.input_path,
                 info.s3_output_uri,
-                info.ipppssoot
+                info.crds_config
             ],
         },
         "timeout": {

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -108,7 +108,7 @@ resource "aws_batch_job_definition" "calcloud" {
   type                 = "container"
   container_properties = <<CONTAINER_PROPERTIES
   { 
-    "command": ["Ref::command", "Ref::s3_output_path", "Ref::dataset"],
+    "command": ["Ref::command", "Ref::dataset", "Ref::input_path", "Ref::s3_output_path", "Ref::crds_config"],
     "environment": [],
     "image": "${aws_ecr_repository.caldp_ecr.repository_url}:${data.aws_ecr_image.caldp_latest.image_tag}",
     "jobRoleArn": "${aws_iam_role.batch_job_role.arn}",
@@ -122,9 +122,11 @@ resource "aws_batch_job_definition" "calcloud" {
   CONTAINER_PROPERTIES
 
   parameters = {
-    "command" = "caldp-process-aws"
+    "command" = "caldp-process"
     "dataset" = "j8cb010b0"
+    "input_path" = "astroquery:"
     "s3_output_path" = "s3://${aws_s3_bucket.calcloud.bucket}"
+    "crds_config" = "caldp-config-offsite"
   }  
 
   depends_on = [


### PR DESCRIPTION
Changed the command sequence to make calcloud compatible with current caldp calling sequence. Confirmed that calibration jobs are succeeding on AWS Batch with this current version and caldp master branch. 