### PR TITLE
Unique  resource naming + SSM parameters

### DIFF
--- a/terraform/batch-outlier.tf
+++ b/terraform/batch-outlier.tf
@@ -1,28 +1,27 @@
 resource "aws_batch_job_queue" "batch_outlier_queue" {
+  name = "calcloud-hst-outlier-queue${local.environment}"
   compute_environments = [
     aws_batch_compute_environment.calcloud_outlier.arn
   ]
-  name = "calcloud-hst-outlier-queue"
   priority = 10
   state = "ENABLED"
-  
+
 }
 
 resource "aws_batch_compute_environment" "calcloud_outlier" {
-  compute_environment_name = "calcloud-hst-outlier"
+  compute_environment_name = "calcloud-hst-outlier${local.environment}"
   type = "MANAGED"
-  service_role = var.aws_batch_job_role_arn
+  service_role = data.aws_ssm_parameter.batch_service_role.value
 
   compute_resources {
     allocation_strategy = "BEST_FIT"
-    instance_role = var.ecs_instance_role_arn
+    instance_role = data.aws_ssm_parameter.ecs_instance_role.value
     type = "EC2"
     bid_percentage = 0
     tags = {}
-    subnets             = [var.single_batch_subnet_id]
-    security_group_ids  = [
-      var.batchsg_id,
-    ]
+    subnets             = local.batch_subnet_ids
+    security_group_ids  = local.batch_sgs
+
     instance_type = [
        "c5.9xlarge",      #  36 cores, 72G ram
     ]
@@ -36,4 +35,3 @@ resource "aws_batch_compute_environment" "calcloud_outlier" {
   }
   lifecycle { ignore_changes = [compute_resources.0.desired_vcpus] }
 }
-

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -10,17 +10,18 @@ data "template_file" "userdata" {
 }
 
 resource "aws_launch_template" "hstdp" {
+  name = "calcloud-hst-worker${local.environment}"
   description             = "Template for cluster worker nodes updated to limit stopped container lifespan"
   ebs_optimized           = "false"
-  image_id                = "ami-07a63940735aebd38" # this is an amazon ECS community AMI
+  image_id                = data.aws_ssm_parameter.batch_ami_id.value
   tags                    = {
-    "Name"         = "calcloud-hst-worker"
-    "calcloud-hst" = "calcloud-hst-worker"
+    "Name"         = "calcloud-hst-worker${local.environment}"
+    "calcloud-hst" = "calcloud-hst-worker${local.environment}"
   }
   user_data               = base64encode(data.template_file.userdata.rendered)
-  vpc_security_group_ids  = [
-        var.batchsg_id,
-  ]
+
+  vpc_security_group_ids  = local.batch_sgs
+
   block_device_mappings {
     device_name = "/dev/xvda"
 
@@ -33,7 +34,7 @@ resource "aws_launch_template" "hstdp" {
             }
   }
   iam_instance_profile {
-    arn = var.ecs_instance_role_arn
+    arn = data.aws_ssm_parameter.ecs_instance_role.value
   }
   monitoring {
     enabled = true
@@ -42,45 +43,43 @@ resource "aws_launch_template" "hstdp" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "Name" = "calcloud-hst-worker"
-      "calcloud-hst" = "calcloud-hst-worker"
+      "Name" = "calcloud-hst-worker${local.environment}"
+      "calcloud-hst" = "calcloud-hst-worker${local.environment}"
     }
   }
 
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "Name" = "calcloud-hst-worker"
-      "calcloud-hst" = "calcloud-hst-worker"
+      "Name" = "calcloud-hst-worker${local.environment}"
+      "calcloud-hst" = "calcloud-hst-worker${local.environment}"
     }
   }
 }
 
 resource "aws_batch_job_queue" "batch_queue" {
+  name = "calcloud-hst-queue${local.environment}"
   compute_environments = [
     aws_batch_compute_environment.calcloud.arn
   ]
-  name = "calcloud-hst-queue"
   priority = 10
   state = "ENABLED"
-  
+
 }
 
 resource "aws_batch_compute_environment" "calcloud" {
-  compute_environment_name  = "calcloud-hst"
+  compute_environment_name  = "calcloud-hst${local.environment}"
   type = "MANAGED"
-  service_role = var.aws_batch_service_role_arn
+  service_role = data.aws_ssm_parameter.batch_service_role.value
 
   compute_resources {
     allocation_strategy = "BEST_FIT"
-    instance_role = var.ecs_instance_role_arn
+    instance_role = data.aws_ssm_parameter.ecs_instance_role.value
     type = "EC2"
     bid_percentage = 0
     tags = {}
-    subnets             = [var.single_batch_subnet_id]
-    security_group_ids  = [
-      var.batchsg_id,
-    ]
+    subnets             = local.batch_subnet_ids
+    security_group_ids  = local.batch_sgs
     instance_type = [
       "m5.large",
       "m5.xlarge",
@@ -97,7 +96,7 @@ resource "aws_batch_compute_environment" "calcloud" {
 }
 
 resource "aws_ecr_repository" "caldp_ecr" {
-  name                 = "caldp"
+  name                 = "caldp${local.environment}"
 }
 
 data "aws_ecr_image" "caldp_latest" {
@@ -106,14 +105,14 @@ data "aws_ecr_image" "caldp_latest" {
 }
 
 resource "aws_batch_job_definition" "calcloud" {
-  name                 = "calcloud-hst-caldp-job-definition"
+  name                 = "calcloud-hst-caldp-job-definition${local.environment}"
   type                 = "container"
   container_properties = <<CONTAINER_PROPERTIES
-  { 
+  {
     "command": ["Ref::command", "Ref::dataset", "Ref::input_path", "Ref::s3_output_path", "Ref::crds_config"],
     "environment": [],
     "image": "${aws_ecr_repository.caldp_ecr.repository_url}:${data.aws_ecr_image.caldp_latest.image_tag}",
-    "jobRoleArn": "${var.aws_batch_job_role_arn}",
+    "jobRoleArn": data.aws_ssm_parameter.batch_job_role.value,
     "memory": 2560,
     "mountPoints": [],
     "resourceRequirements": [],
@@ -129,14 +128,14 @@ resource "aws_batch_job_definition" "calcloud" {
     "input_path" = "astroquery:"
     "s3_output_path" = "s3://${aws_s3_bucket.calcloud.bucket}"
     "crds_config" = "caldp-config-offsite"
-  }  
+  }
 }
 
 resource "aws_s3_bucket" "calcloud" {
-  bucket = var.s3_bucket_name
+  bucket = "calcloud-hst-pipeline-outputs${local.environment}"
   tags = {
-    "CALCLOUD" = "calcloud-hst-pipeline-outputs"
-    "Name"     = "calcloud-hst-pipeline-outputs"
+    "CALCLOUD" = "calcloud-hst-pipeline-outputs${local.environment}"
+    "Name"     = "calcloud-hst-pipeline-outputs${local.environment}"
   }
 }
 

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -126,16 +126,16 @@ resource "aws_batch_job_definition" "calcloud" {
     "command" = "caldp-process"
     "dataset" = "j8cb010b0"
     "input_path" = "astroquery:"
-    "s3_output_path" = "s3://${aws_s3_bucket.calcloud.bucket}"
+    "s3_output_path" = "s3://${aws_s3_bucket.calcloud.bucket}/outputs"
     "crds_config" = "caldp-config-offsite"
   }
 }
 
 resource "aws_s3_bucket" "calcloud" {
-  bucket = "calcloud-hst-pipeline-outputs${local.environment}"
+  bucket = "calcloud-processing${local.environment}"
   tags = {
-    "CALCLOUD" = "calcloud-hst-pipeline-outputs${local.environment}"
-    "Name"     = "calcloud-hst-pipeline-outputs${local.environment}"
+    "CALCLOUD" = "calcloud-processing${local.environment}"
+    "Name"     = "calcloud-processing${local.environment}"
   }
 }
 

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -112,7 +112,7 @@ resource "aws_batch_job_definition" "calcloud" {
     "command": ["Ref::command", "Ref::dataset", "Ref::input_path", "Ref::s3_output_path", "Ref::crds_config"],
     "environment": [],
     "image": "${aws_ecr_repository.caldp_ecr.repository_url}:${data.aws_ecr_image.caldp_latest.image_tag}",
-    "jobRoleArn": data.aws_ssm_parameter.batch_job_role.value,
+    "jobRoleArn": "${data.aws_ssm_parameter.batch_job_role.value}",
     "memory": 2560,
     "mountPoints": [],
     "resourceRequirements": [],

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,11 @@
+locals {
+       batch_subnet_ids = split(",", data.aws_ssm_parameter.batch_subnet_ids.value)
+       
+       batch_sgs = split(",", data.aws_ssm_parameter.batch_sgs.value)
+
+       # SSM environment value can be overridden,  also tweaked with "-" below
+       pre_environment = var.environment != null ? var.environment : data.aws_ssm_parameter.environment.value
+
+       # Unless the pre_environment is an empty string,  prepend an implicit "-" to the final environment value
+       environment = local.pre_environment == "" ? "" : join("", ["-", local.pre_environment])
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,37 @@
+output batch_ami_id {
+  value       = data.aws_ssm_parameter.batch_ami_id.value
+  description = "AMI ID ssm parameter, for ITSD's latest Batch worker AMI"
+}
+
+output batch_subnet_ids {
+  value       = local.batch_subnet_ids
+  description = "ID ssm parameter for subnets used by AWS batch"
+}
+
+output batch_job_role {
+  value = data.aws_ssm_parameter.batch_job_role.value
+}
+
+output batch_service_role {
+  value = data.aws_ssm_parameter.batch_service_role.value
+}
+
+output ecs_instance_role {
+  value = data.aws_ssm_parameter.ecs_instance_role.value
+}
+
+output batch_sgs {
+  value = local.batch_sgs
+}
+
+output environment {
+  value = local.environment
+}
+
+output region {
+  value = var.region
+}
+
+output vpc {
+  value = data.aws_ssm_parameter.vpc.value
+}

--- a/terraform/parameters.tf
+++ b/terraform/parameters.tf
@@ -1,0 +1,32 @@
+data aws_ssm_parameter batch_ami_id {
+  name = "/AMI/STSCI-HST-REPRO-ECS"
+}
+
+data aws_ssm_parameter batch_subnet_ids {
+  name = "/subnets/private"
+}
+
+data aws_ssm_parameter batch_job_role {
+  name = "/iam/roles/aws_batch_job_role"
+}
+
+data aws_ssm_parameter batch_service_role {
+  name = "/iam/roles/aws_batch_service_role"
+}
+
+data aws_ssm_parameter ecs_instance_role {
+  name = "/iam/roles/ecs_instance_role"
+}
+
+data aws_ssm_parameter batch_sgs {
+  name = "/vpc/sgs/batch"
+}
+
+data aws_ssm_parameter environment {
+  name = "environment"
+}
+
+data aws_ssm_parameter vpc {
+   name = "vpc"
+}
+

--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "s3" {}
-}

--- a/terraform/template.tfvars
+++ b/terraform/template.tfvars
@@ -1,8 +1,6 @@
+# latest is default
 image_tag = "latest"
-region = "us-east-1"
-batchsg_id = "your-sg-id-here"
-ecs_instance_role_arn = "arn:aws:iam::your-account-id:instance-profile/your-role-name"
-aws_batch_service_role_arn = "arn:aws:iam::your-account-id:role/your-role-name"
-single_batch_subnet_id = "subnet-your-subnet-id"
-aws_batch_job_role_arn = "arn:aws:iam::your-account-id:role/your-job-role"
-s3_bucket_name = "your-s3-bucket-name"
+
+# SSM provides a default account value overriden by this,  e.g. sb, dev, test, prod, sb-bhayden, ...
+environment = "your-unique-suffix"
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,31 +1,16 @@
-variable "region" {
-  type = string
-}
-
-variable "batchsg_id" {
-  type = string
-}
-
-variable "ecs_instance_role_arn" {
-  type = string
-}
-
-variable "aws_batch_service_role_arn" {
-  type = string
-}
-
 variable "image_tag" {
   type = string
+  default = "latest"
 }
 
-variable "single_batch_subnet_id" {
+variable "environment" {
+  description = "Override to environment value provided by SSM,  takes precedence if specified."
   type = string
+  default = null
 }
 
-variable "aws_batch_job_role_arn" {
+variable region {
+  description = "AWS region"
   type = string
-}
-
-variable "s3_bucket_name" {
-  type = string
+  default = "us-east-1"
 }


### PR DESCRIPTION
Draft Terraform changes to make resource names unique enabling multiple conflict-free deployments per account.

Configuration for all resources created by ITSD is now input via SSM
parameters leaving only region, environment, and image_tag variables, all of
which have reasonable default values.  environment is also defined by
default for each account, so effectively a default calcloud build can
be completely parameter free using only the assumptions region=us-east-1
and image_tag=latest.

Among the resources now defined by SSM parameters are the Batch AMI ID,
VPC, and subnets.

This update adds three new files:

1. parameters.tf which is used  to define SSM parameters much like
varaibles.tf defines variables.  (Made up convention)

2. locals.tf which defines a few computed (local) values in one place
so they can be referenced simply everywhere else.  (Standard convention)
As an example,  these enable the SSM value of environment to be
overridden using a variable,  and also tweak "-" handling so the ""
environment is not seen as an orphan trailing slash.

3. outputs.tf which defines values  which should be printed out after
each Terraform run. (Standard convention)