### PR TITLE
removed deprecated direct setting of memory and vcpu 

### DIFF
--- a/calcloud/submit.py
+++ b/calcloud/submit.py
@@ -19,8 +19,16 @@ def submit_job(plan_tuple):
         "jobQueue": info.job_queue,
         "jobDefinition": info.job_definition,
         "containerOverrides": {
-            "vcpus": info.vcpus,
-            "memory": info.memory,
+            "resourceRequirements": [
+                {
+                    "value": f"{info.memory}",
+                    "type": "MEMORY"
+                },
+                {
+                    "value": f"{info.vcpus}",
+                    "type": "VCPU"
+                }
+            ],
             "command": [info.command, info.ipppssoot, info.input_path, info.s3_output_uri, info.crds_config],
         },
         "timeout": {


### PR DESCRIPTION
and used resourceRequirement which could facilitate fargate in the future

good news bad news
good news: could use fargate in future, no longer using deprecated params according to aws docs

bad news: the overrides don't show up anywhere in the console, I had to make sure they were working by hardcoding a small number and watching a job fail