### PR TITLE
Move job control metadata to control/ipppssoot/job.json enabling other control files for  ipppssoot

### DIFF
--- a/calcloud/io.py
+++ b/calcloud/io.py
@@ -326,8 +326,8 @@ class ControlIo(S3Io):
     control store.
 
     >>> comm = get_io_bundle()
-    >>> comm.metadata.path('lcw303cjq/env') #doctest: +ELLIPSIS
-    's3://.../comtrol/lcw303cjq/env'
+    >>> comm.control.path('lcw303cjq/env') #doctest: +ELLIPSIS
+    's3://.../control/lcw303cjq/env'
     """
 
 

--- a/calcloud/lambda_submit.py
+++ b/calcloud/lambda_submit.py
@@ -30,8 +30,8 @@ def main(ipppssoot, bucket_name):
     ipppssoot = ipppssoot.lower()
 
     try:
-        ctrl_msg = comm.control.get(ipppssoot)
-    except comm.control.client.exceptions.NoSuchKey:
+        ctrl_msg = comm.metadata.get(ipppssoot)
+    except comm.metadata.client.exceptions.NoSuchKey:
         ctrl_msg = dict()
 
     # memory_retries is incremented in the batch failure event if it's a memory fail
@@ -50,5 +50,5 @@ def main(ipppssoot, bucket_name):
         comm.messages.put("error-" + ipppssoot)
         return
 
-    comm.control.put(ipppssoot, ctrl_msg)
+    comm.metadata.put(ipppssoot, ctrl_msg)
     comm.messages.put("submit-" + ipppssoot)

--- a/lambda/batch_events/batch_event_handler.py
+++ b/lambda/batch_events/batch_event_handler.py
@@ -18,8 +18,8 @@ def lambda_handler(event, context):
     comm.messages.delete("all-" + ipppssoot)
 
     try:
-        ctrl_msg = comm.control.get(ipppssoot)
-    except comm.control.client.exceptions.NoSuchKey:
+        ctrl_msg = comm.metadata.get(ipppssoot)
+    except comm.metadata.client.exceptions.NoSuchKey:
         ctrl_msg = dict()
 
     ctrl_msg["ipppssoot"] = ipppssoot
@@ -45,6 +45,6 @@ def lambda_handler(event, context):
         print("Failure for", ipppssoot, "no automatic retry for", fail_reason)
 
     # XXXX Since retry count used in planning, control output must precede rescue message
-    comm.control.put(ipppssoot, ctrl_msg)
+    comm.metadata.put(ipppssoot, ctrl_msg)
     comm.messages.put(continuation_msg)
     print(ctrl_msg)

--- a/lambda/s3_trigger/s3_trigger_handler.py
+++ b/lambda/s3_trigger/s3_trigger_handler.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
 
     comm = io.get_io_bundle(bucket_name)
 
-    comm.control.delete(ipst)  # biggest difference between "placed" and "rescue"
+    comm.metadata.delete(ipst)  # biggest difference between "placed" and "rescue"
     comm.messages.delete("placed-" + ipst)
 
     lambda_submit.main(ipst, bucket_name)


### PR DESCRIPTION
Move job metadata from contrl/ipppssoot to control/ipppssoot/job.json.
Convert comm.control to comm.metadata and relegate comm.control to simple
S3Io on arbitrary prefixes like comm.inputs and comm.outputs.