### PR TITLE
added 30 day log retention policy to all lambda functions

### DIFF
--- a/terraform/lambda_batch_events.tf
+++ b/terraform/lambda_batch_events.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_batchEvents" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 900
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_blackboard" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 300
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {

--- a/terraform/lambda_broadcast.tf
+++ b/terraform/lambda_broadcast.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_broadcast" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 300
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {

--- a/terraform/lambda_job_delete.tf
+++ b/terraform/lambda_job_delete.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_deleteJob" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 900
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {

--- a/terraform/lambda_job_rescue.tf
+++ b/terraform/lambda_job_rescue.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_rescueJob" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 300
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_submit" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 30
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {

--- a/terraform/lambda_refresh_cache_logging.tf
+++ b/terraform/lambda_refresh_cache_logging.tf
@@ -8,6 +8,7 @@ module "calcloud_lambda_refreshCache" {
   runtime       = "python3.6"
   publish       = false
   timeout       = 900
+  cloudwatch_logs_retention_in_days = 30
 
   source_path = [
     {


### PR DESCRIPTION
unfortunately there is not a straightforward and easy way to deal with the retention policy for aws batch logs. See CALCLOUD-216