### PR TITLE
new HST keywords for cloud software versions

### DIFF
--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -114,7 +114,11 @@ resource "aws_batch_job_definition" "calcloud" {
   container_properties = <<CONTAINER_PROPERTIES
   {
     "command": ["Ref::command", "Ref::dataset", "Ref::input_path", "Ref::s3_output_path", "Ref::crds_config"],
-    "environment": [],
+    "environment": [
+      {"name": "AWSDPVER", "value": "${var.awsdpver}"},
+      {"name": "AWSYSVER", "value": "${var.awsysver}"},
+      {"name": "CSYS_VER", "value": "${var.csys_ver}"}
+    ],
     "image": "${aws_ecr_repository.caldp_ecr.repository_url}:${data.aws_ecr_image.caldp_latest.image_tag}",
     "jobRoleArn": "${data.aws_ssm_parameter.batch_job_role.value}",
     "memory": 2560,

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,8 +3,8 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.2.0"
-CALDP_VER="0.1.2"
+CALCLOUD_VER="0.2.1"
+CALDP_VER="0.1.3"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20201208_DRZ_final"
 # this is the tag that the image will have in AWS ECR
 CALDP_IMAGE_TAG="latest"
@@ -62,7 +62,7 @@ docker push ${CALDP_DOCKER_IMAGE}
 # deploy rest of terraform
 cd ../calcloud-${CALCLOUD_VER}/terraform
 # manual confirmation required
-awsudo $ADMIN_ARN terraform apply
+awsudo $ADMIN_ARN terraform apply -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CAL_BASE_IMAGE##*:}"
 
 # make sure needed prefixes exist in primary s3 bucket
 # pulls the bucket name in from a tag called Name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,3 +14,21 @@ variable region {
   type = string
   default = "us-east-1"
 }
+
+variable awsdpver {
+  description = "HST keyword for caldp repo tag version"
+  type = string
+  default = "undefined"
+}
+
+variable awsysver {
+  description = "HST keyword for calcloud repo tag version"
+  type = string
+  default = "undefined"
+}
+
+variable csys_ver {
+  description = "HST keyword for docker base calibration image tag"
+  type = string
+  default = "undefined"
+}


### PR DESCRIPTION
3 HST keywords are passed through the deploy script into the job definition as environment variables, where they're used by caldp to set the keywords in the raw headers, which pass through to the calibrated products (verified). 