### PR TITLE
terraform provider and module version pinning

### DIFF
--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -2,6 +2,35 @@ provider "aws" {
   region  = var.region
 }
 
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.29.0"
+    }
+    hashicorp-template = {
+      source = "hashicorp/template"
+      version = "~> 2.2.0"
+    }
+    hashicorp-null = {
+      source = "hashicorp/null"
+      version = "~> 3.1.0"
+    }
+    hashicorp-external = {
+      source = "hashicorp/external"
+      version = "~> 2.1.0"
+    }
+    hashicorp-local = {
+      source = "hashicorp/local"
+      version = "~> 2.1.0"
+    }
+    hashicorp-random = {
+      source = "hashicorp/random"
+      version = "~> 3.1.0"
+    }
+  }
+}
+
 data "template_file" "userdata" {
   template = file("${path.module}/user_data.sh")
   vars = {

--- a/terraform/lambda_batch_events.tf
+++ b/terraform/lambda_batch_events.tf
@@ -1,5 +1,6 @@
 module "calcloud_lambda_batchEvents" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
 
   function_name = "calcloud-job-events${local.environment}"
   description   = "listens for Batch failure events from cloudWatch event rule"

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -1,5 +1,6 @@
 module "calcloud_lambda_blackboard" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
 
   function_name = "calcloud-job-blackboard${local.environment}"
   description   = "scrapes the Batch console for job metadata and posts to S3 bucket for on-premise poller"

--- a/terraform/lambda_broadcast.tf
+++ b/terraform/lambda_broadcast.tf
@@ -1,5 +1,6 @@
 module "calcloud_lambda_broadcast" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
 
   function_name = "calcloud-broadcast${local.environment}"
   description   = "Broadcasts the specified ipppssoot (must be in error state) by deleting all outputs and messages and re-placing."

--- a/terraform/lambda_job_delete.tf
+++ b/terraform/lambda_job_delete.tf
@@ -1,5 +1,6 @@
 module "calcloud_lambda_deleteJob" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
 
   function_name = "calcloud-job-delete${local.environment}"
   description   = "accepts messages from s3 event and deletes either individual jobs by ipppssoot, or all active jobs"

--- a/terraform/lambda_job_rescue.tf
+++ b/terraform/lambda_job_rescue.tf
@@ -1,5 +1,6 @@
 module "calcloud_lambda_rescueJob" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
 
   function_name = "calcloud-job-rescue${local.environment}"
   description   = "Rescues the specified ipppssoot (must be in error state) by deleting all outputs and messages and re-placing."

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -1,5 +1,7 @@
 module "calcloud_lambda_submit" {
   source = "terraform-aws-modules/lambda/aws"
+  # https://github.com/hashicorp/terraform/issues/17211
+  version = "~> 1.43.0"
 
   function_name = "calcloud-job-submit${local.environment}"
   description   = "looks for placed-ipppssoot messages and submits jobs to Batch"

--- a/terraform/lambda_refresh_cache_logging.tf
+++ b/terraform/lambda_refresh_cache_logging.tf
@@ -1,5 +1,6 @@
 module "calcloud_lambda_refreshCache" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
 
   function_name = "calcloud-fileshare-refresh_cache${local.environment}"
   description   = "listens for refresh cache operations and logs them"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,3 +32,9 @@ variable csys_ver {
   type = string
   default = "undefined"
 }
+
+variable pinned_tf_ver {
+  description = "the intended value of the terraform installation in the environment"
+  type = string
+  default = "0.14.7"
+}


### PR DESCRIPTION
unfortunately there doesn't seem to be a way to globally pin the `terraform-aws-modules/lambda/aws` version, and you also cannot turn it into a variable (because it is only valid at `init`, it cannot be changed on-the-fly in a `plan` or `apply`). So the only option seems to be to specify it uniquely in every instantiation of an object from the module.