### PR TITLE
CALCLOUD-228 Enhanced CALDP error handling and CALCLOUD failure events

### DIFF
--- a/calcloud/exit_codes.py
+++ b/calcloud/exit_codes.py
@@ -1,0 +1,141 @@
+"""These numerical values are returned by CALDP as process exit status.
+
+This file should be shared/coordinated *verbatim* with CALCLOUD to ensure that
+CALCLOUD correctly identifies and handles exit status coming from CALDP.
+
+The intent of these codes is to identify specific error cases defined by CALDP.
+
+Any errors not explicitly handled by CALDP are intended to be mapped to
+generic values of 0 or 1 to prevent conflicts with these codes.
+"""
+import sys
+
+_EXIT_CODES = dict(
+    SUCCESS=0,
+    GENERIC_ERROR=1,
+    CMDLINE_ERROR=2,
+    INPUT_TAR_FILE_ERROR=21,
+    ASTROQUERY_ERROR=22,
+    STAGE1_ERROR=23,
+    STAGE2_ERROR=24,
+    S3_UPLOAD_ERROR=25,
+    S3_DOWNLOAD_ERROR=26,
+    BESTREFS_ERROR=27,
+    CREATE_PREVIEWS_ERROR=28,
+    SUBPROCESS_MEMORY_ERROR=31,  # See caldp-process for this
+    CALDP_MEMORY_ERROR=32,
+    CONTAINER_MEMORY_ERROR=33,
+)
+
+
+_NAME_EXPLANATIONS = dict(
+    SUCCESS="Processing completed successfully.",
+    GENERIC_ERROR="An error with no specific CALDP handling occurred somewhere.",
+    CMDLINE_ERROR="The program command line invocation was incorrect.",
+    INPUT_TAR_FILE_ERROR="An error occurred locating or untarring the inputs tarball.",
+    ASTROQUERY_ERROR="An error occurred downloading astroqery: inputs",
+    STAGE1_ERROR="An error occurred in this instrument's stage1 processing step. e.g. calxxx",
+    STAGE2_ERROR="An error occurred in this instrument's stage2 processing step, e.g astrodrizzle",
+    S3_UPLOAD_ERROR="An error occurred uploading the outputs tarball to S3.",
+    S3_DOWNLOAD_ERROR="An error occurred downloading inputs from S3.",
+    BESTREFS_ERROR="An error occurred computing or downloading CRDS reference files.",
+    CREATE_PREVIEWS_ERROR="An error occurrred creating preview files for processed data.",
+    # Potentially see caldp-process bash script for this
+    SUBPROCESS_MEMORY_ERROR="A Python MemoryError was detected by scanning the process.txt log.",
+    CALDP_MEMORY_ERROR="CALDP generated a Python MemoryError during processing or preview creation.",
+    # This is never directly returned.  It's intended to be used to trigger a container memory limit
+    CONTAINER_MEMORY_ERROR="The Batch/ECS container runtime killed the job due to memory limits.",
+)
+
+_CODE_TO_NAME = dict()
+
+# Set up original module global variables / named constants
+for (name, code) in _EXIT_CODES.items():
+    globals()[name] = code
+    _CODE_TO_NAME[code] = name
+    _CODE_TO_NAME[str(code)] = name
+    assert name in _NAME_EXPLANATIONS
+
+
+def explain(exit_code):
+    """Return the text explanation for the specified `exit_code`.
+
+    >>> explain(SUCCESS)
+    'EXIT SUCCESS[0]: Processing completed successfully.'
+
+    >>> explain("SUCCESS")
+    'EXIT SUCCESS[0]: Processing completed successfully.'
+
+    >>> explain(GENERIC_ERROR)
+    'EXIT GENERIC_ERROR[1]: An error with no specific CALDP handling occurred somewhere.'
+
+    >>> explain(SUBPROCESS_MEMORY_ERROR)
+    'EXIT SUBPROCESS_MEMORY_ERROR[31]: A Python MemoryError was detected by scanning the process.txt log.'
+    """
+    if exit_code in _CODE_TO_NAME:
+        name = _CODE_TO_NAME[exit_code]
+        explanation = _NAME_EXPLANATIONS[name]
+    elif exit_code in _NAME_EXPLANATIONS:
+        name = exit_code
+        exit_code = globals()[name]
+        explanation = _NAME_EXPLANATIONS[name]
+    else:
+        raise ValueError("Invalid exit_code: " + repr(exit_code))
+    return f"EXIT {name}[{exit_code}]: {explanation}"
+
+
+def print_explanations(error_codes):
+    """Print out the text explanation of each error code in `error_codes`.
+
+    >>> print_explanations([32])
+    EXIT CALDP_MEMORY_ERROR[32]: CALDP generated a Python MemoryError during processing or preview creation.
+    """
+    for code in error_codes:
+        print(explain(code))
+
+
+def is_memory_error(exit_code):
+    """Return  True IFF `exit_code` indicates some kind of memory error.
+
+    exit_code may be specified as a name string or integer exit code.
+
+    >>> is_memory_error(GENERIC_ERROR)
+    False
+
+    >>> is_memory_error(SUBPROCESS_MEMORY_ERROR)
+    True
+
+    >>> is_memory_error(CALDP_MEMORY_ERROR)
+    True
+
+    >>> is_memory_error(CONTAINER_MEMORY_ERROR)
+    True
+
+    >>> is_memory_error("GENERIC_ERROR")
+    False
+
+    >>> is_memory_error("SUBPROCESS_MEMORY_ERROR")
+    True
+    """
+    memory_error_names = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR"]
+    return (exit_code in [globals()[name] for name in memory_error_names]) or (exit_code in memory_error_names)
+
+
+def test():
+    import doctest
+
+    try:
+        from caldp import exit_codes
+    except ImportError:
+        from calcloud import exit_codes
+    return doctest.testmod(exit_codes)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "test":
+        print(test())
+    elif len(sys.argv) >= 2 and sys.argv[1] == "explain":
+        print_explanations(sys.argv[2:])
+    else:
+        print("usage: python -m caldp.exit_codes [test|explain] [explain_codes...]")
+        sys.exit(globals()["CMDLINE_ERROR"])  # the things we do for flake8...

--- a/calcloud/exit_codes.py
+++ b/calcloud/exit_codes.py
@@ -10,6 +10,10 @@ generic values of 0 or 1 to prevent conflicts with these codes.
 """
 import sys
 
+
+_MEMORY_ERROR_NAMES = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR"]
+
+
 _EXIT_CODES = dict(
     SUCCESS=0,
     GENERIC_ERROR=1,
@@ -80,7 +84,7 @@ def explain(exit_code):
         exit_code = globals()[name]
         explanation = _NAME_EXPLANATIONS[name]
     else:
-        raise ValueError("Invalid exit_code: " + repr(exit_code))
+        raise ValueError("Unhandled exit_code: " + repr(exit_code))
     return f"EXIT {name}[{exit_code}]: {explanation}"
 
 
@@ -117,8 +121,7 @@ def is_memory_error(exit_code):
     >>> is_memory_error("SUBPROCESS_MEMORY_ERROR")
     True
     """
-    memory_error_names = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR"]
-    return (exit_code in [globals()[name] for name in memory_error_names]) or (exit_code in memory_error_names)
+    return (exit_code in [globals()[name] for name in _MEMORY_ERROR_NAMES]) or (exit_code in _MEMORY_ERROR_NAMES)
 
 
 def test():

--- a/calcloud/exit_codes.py
+++ b/calcloud/exit_codes.py
@@ -8,8 +8,6 @@ The intent of these codes is to identify specific error cases defined by CALDP.
 Any errors not explicitly handled by CALDP are intended to be mapped to
 generic values of 0 or 1 to prevent conflicts with these codes.
 """
-import sys
-
 
 _MEMORY_ERROR_NAMES = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR"]
 
@@ -65,16 +63,21 @@ def explain(exit_code):
     """Return the text explanation for the specified `exit_code`.
 
     >>> explain(SUCCESS)
-    'EXIT SUCCESS[0]: Processing completed successfully.'
+    'EXIT - SUCCESS[0]: Processing completed successfully.'
 
     >>> explain("SUCCESS")
-    'EXIT SUCCESS[0]: Processing completed successfully.'
+    'EXIT - SUCCESS[0]: Processing completed successfully.'
 
     >>> explain(GENERIC_ERROR)
-    'EXIT GENERIC_ERROR[1]: An error with no specific CALDP handling occurred somewhere.'
+    'EXIT - GENERIC_ERROR[1]: An error with no specific CALDP handling occurred somewhere.'
 
     >>> explain(SUBPROCESS_MEMORY_ERROR)
-    'EXIT SUBPROCESS_MEMORY_ERROR[31]: A Python MemoryError was detected by scanning the process.txt log.'
+    'EXIT - SUBPROCESS_MEMORY_ERROR[31]: A Python MemoryError was detected by scanning the process.txt log.'
+
+    >>> explain(999)
+    Traceback (most recent call last):
+    ...
+    ValueError: Unhandled exit_code: 999
     """
     if exit_code in _CODE_TO_NAME:
         name = _CODE_TO_NAME[exit_code]
@@ -85,17 +88,7 @@ def explain(exit_code):
         explanation = _NAME_EXPLANATIONS[name]
     else:
         raise ValueError("Unhandled exit_code: " + repr(exit_code))
-    return f"EXIT {name}[{exit_code}]: {explanation}"
-
-
-def print_explanations(error_codes):
-    """Print out the text explanation of each error code in `error_codes`.
-
-    >>> print_explanations([32])
-    EXIT CALDP_MEMORY_ERROR[32]: CALDP generated a Python MemoryError during processing or preview creation.
-    """
-    for code in error_codes:
-        print(explain(code))
+    return f"EXIT - {name}[{exit_code}]: {explanation}"
 
 
 def is_memory_error(exit_code):
@@ -122,23 +115,3 @@ def is_memory_error(exit_code):
     True
     """
     return (exit_code in [globals()[name] for name in _MEMORY_ERROR_NAMES]) or (exit_code in _MEMORY_ERROR_NAMES)
-
-
-def test():
-    import doctest
-
-    try:
-        from caldp import exit_codes
-    except ImportError:
-        from calcloud import exit_codes
-    return doctest.testmod(exit_codes)
-
-
-if __name__ == "__main__":
-    if len(sys.argv) == 2 and sys.argv[1] == "test":
-        print(test())
-    elif len(sys.argv) >= 2 and sys.argv[1] == "explain":
-        print_explanations(sys.argv[2:])
-    else:
-        print("usage: python -m caldp.exit_codes [test|explain] [explain_codes...]")
-        sys.exit(globals()["CMDLINE_ERROR"])  # the things we do for flake8...

--- a/calcloud/io.py
+++ b/calcloud/io.py
@@ -535,7 +535,7 @@ class IoBundle:
         self.messages.delete(ids)
         self.xdata.delete(ids)  # IPPPSSOOT control metadata / retry status
 
-    def clear(self, ids="all"):
+    def clean(self, ids="all"):
         """Delete every S3 file managed by this IoBundle."""
         self.reset(ids)
         self.control.delete(ids)  # Memory model inputs

--- a/calcloud/io.py
+++ b/calcloud/io.py
@@ -533,13 +533,13 @@ class IoBundle:
         """Delete outputs, messages, and control files."""
         self.outputs.delete(ids)
         self.messages.delete(ids)
-        self.xdata.delete(ids)
+        self.xdata.delete(ids)  # IPPPSSOOT control metadata / retry status
 
     def clear(self, ids="all"):
         """Delete every S3 file managed by this IoBundle."""
         self.reset(ids)
-        self.control.delete(ids)
-        self.inputs.delete(ids)
+        self.control.delete(ids)  # Memory model inputs
+        self.inputs.delete(ids)  # Input tarballs
 
 
 def get_io_bundle(bucket=s3.DEFAULT_BUCKET, client=None):

--- a/calcloud/log.py
+++ b/calcloud/log.py
@@ -89,11 +89,11 @@ class HstdpLogger:
 
         # verbose_level handles HSTDP verbosity,  defaulting to 0 for no debug
         try:
-            verbose_level = os.environ.get("HSTDP_VERBOSITY", 0)
+            verbose_level = os.environ.get("CALCLOUD_VERBOSITY", 0)
             self.verbose_level = int(verbose_level)
         except Exception:
             warning(
-                "Bad format for HSTDP_VERBOSITY =",
+                "Bad format for CALCLOUD_VERBOSITY =",
                 repr(verbose_level),
                 "Use e.g. -1 to squelch info, 0 for no debug,  50 for default debug output. 100 max debug.",
             )

--- a/lambda/batch_events/batch_event_handler.py
+++ b/lambda/batch_events/batch_event_handler.py
@@ -20,21 +20,24 @@ memory related failures, otherwise an error-ipppssoot message is sent.
 import os
 
 from calcloud import io
+from calcloud import exit_codes
 
 
 def lambda_handler(event, context):
 
     print(event)
 
-    ipppssoot = event["detail"]["container"]["command"][1]
-    bucket = event["detail"]["container"]["command"][2].split("/")[2]
-    job_id = event["detail"]["jobId"]
-    job_name = event["detail"]["jobName"]  # appears to be ipppssoot
-    attempts = event["detail"]["attempts"]
-    if attempts:
-        fail_reason = attempts[0]["container"]["reason"]
-    else:
-        fail_reason = event["detail"]["statusReason"]
+    detail = event["detail"]
+    job_id = detail["jobId"]
+    job_name = detail["jobName"]  # appears to be ipppssoot
+    status_reason = detail.get("statusReason", "undefined")
+
+    container = event["detail"]["container"]
+    ipppssoot = container["command"][1]
+    bucket = container["command"][2].split("/")[2]
+    container_reason = container.get("reason", "undefined")
+    exit_code = container.get("exitCode", "undefined")
+    exit_reason = exit_codes.explain(exit_code) if exit_code != "undefined" else exit_code
 
     comm = io.get_io_bundle(bucket)
 
@@ -43,18 +46,31 @@ def lambda_handler(event, context):
     metadata["bucket"] = bucket
     metadata["job_id"] = job_id
     metadata["job_name"] = job_name
-    metadata["fail_reason"] = fail_reason
+    metadata["exit_code"] = exit_code
+    metadata["exit_reason"] = exit_reason
+    metadata["status_reason"] = status_reason
+    metadata["container_reason"] = container_reason
+
+    if exit_reason != "undefined":
+        combined_reason = exit_reason
+    elif container_reason != "undefined":
+        combined_reason = container_reason
+    else:
+        combined_reason = status_reason
 
     continuation_msg = "error-" + ipppssoot
-    if fail_reason.startswith("OutOfMemoryError:"):
+
+    if exit_codes.is_memory_error(exit_code) or container_reason.startswith("OutOfMemoryError: Container killed"):
         if not metadata["terminated"] and metadata["memory_retries"] < int(os.environ["MAX_MEMORY_RETRIES"]):
             metadata["memory_retries"] += 1
             continuation_msg = "rescue-" + ipppssoot
             print("Automatic rescue of", ipppssoot, "with memory retry count", metadata["memory_retries"])
         else:
             print("Automatic memory retries for", ipppssoot, "exhausted at", metadata["memory_retries"])
+    elif status_reason.startswith("Operator cancelled"):
+        print("Operator cancelled job", job_id, "for", ipppssoot, "no automatic retry.")
     else:
-        print("Failure for", ipppssoot, "no automatic retry for", fail_reason)
+        print("Failure for", ipppssoot, "no automatic retry for", combined_reason)
 
     # XXXX Since retry count used in planning, control output must precede rescue message
     print(metadata)

--- a/terraform/lambda_job_rescue.tf
+++ b/terraform/lambda_job_rescue.tf
@@ -4,7 +4,7 @@ module "calcloud_lambda_rescueJob" {
 
   function_name = "calcloud-job-rescue${local.environment}"
   description   = "Rescues the specified ipppssoot (must be in error state) by deleting all outputs and messages and re-placing."
-  # the path is relative to the path inside the lambda env, not in the local filesystem. 
+  # the path is relative to the path inside the lambda env, not in the local filesystem.
   handler       = "rescue_handler.lambda_handler"
   runtime       = "python3.6"
   publish       = false
@@ -37,10 +37,10 @@ module "calcloud_lambda_rescueJob" {
   attach_tracing_policy = false
   attach_async_event_policy = false
   # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation. 
+  # will need to parametrize when ITSD takes over role creation.
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_delete_role.value   # XXX Re-use DELETE ROLE
-  
+
   environment_variables = {
     JOBDEFINITIONS = local.job_definitions,
     NORMALQUEUE = aws_batch_job_queue.batch_queue.name,
@@ -59,4 +59,3 @@ resource "aws_lambda_permission" "allow_bucket_rescueLambda" {
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
 }
-

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -5,7 +5,7 @@ module "calcloud_lambda_submit" {
 
   function_name = "calcloud-job-submit${local.environment}"
   description   = "looks for placed-ipppssoot messages and submits jobs to Batch"
-  # the path is relative to the path inside the lambda env, not in the local filesystem. 
+  # the path is relative to the path inside the lambda env, not in the local filesystem.
   handler       = "s3_trigger_handler.lambda_handler"
   runtime       = "python3.6"
   publish       = false
@@ -38,7 +38,7 @@ module "calcloud_lambda_submit" {
   attach_tracing_policy = false
   attach_async_event_policy = false
   # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation. 
+  # will need to parametrize when ITSD takes over role creation.
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
 


### PR DESCRIPTION
Adding a sysexit.py module which supplies the exit_on_exception() and exit_receiver() context managers which support bracketing blocks of code and throwing any exception raised  back up to the program top level.
Adding the exit_codes.py module which defines CALDP error codes and text explanations.
Modifying caldp-process to be more transparent to the error codes issued by process.py and create_previews.py
Modifying process.py, create_previews.py, and messages.py to trap different error cases and report them with unique error codes.
Modifying the batch event handler to handle more event formats,  including Container memory limit, Python MemoryError, and operator cancelled.
Added a search for MemoryError in caldp-process using grep to find trapped memory errors in process.txt
Improved CALCLOUD batch event handler to process varying event formats for: container memory limit, Python memory error, program non-zero exit code,  operator cancelled event.