### PR TITLE
example of an environment-specific variable and generic default

### DIFF
--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -43,6 +43,7 @@ resource "aws_launch_template" "hstdp" {
   description             = "Template for cluster worker nodes updated to limit stopped container lifespan"
   ebs_optimized           = "false"
   image_id                = data.aws_ssm_parameter.batch_ami_id.value
+  update_default_version = true
   tags                    = {
     "Name"         = "calcloud-hst-worker${local.environment}"
     "calcloud-hst" = "calcloud-hst-worker${local.environment}"
@@ -59,7 +60,7 @@ resource "aws_launch_template" "hstdp" {
     encrypted             = "true"
     iops                  = 0
     volume_size           = 150
-    volume_type           = "gp2"
+    volume_type           = lookup(var.lt_ebs_type, local.environment, "gp2")
             }
   }
   iam_instance_profile {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,3 +38,14 @@ variable pinned_tf_ver {
   type = string
   default = "0.14.7"
 }
+
+variable lt_ebs_type {
+  description = "the type of EBS volume used to back the EC2 worker nodes"
+  type = map(string)
+  default = {
+    "-sb" = "gp2"
+    "-dev" = "gp2"
+    "-test" = "gp3"
+    "-ops" = "gp3"
+  }
+}


### PR DESCRIPTION
This is a demonstration of how to setup environment-specific terraform variables.

In this case, use a map(string) variable with environment keys to determine the right EBS type (gp2 for lower-load envs, gp3 for higher load). Use the lookup function to default to a generic "gp2" if the environment is not one of the "official" ones, (i.e., if it's "jmiller")

