### PR TITLE
null IOPS for gp2 causes compute env to go to invalid

### DIFF
--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,8 +3,8 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.2.1"
-CALDP_VER="0.1.3"
+CALCLOUD_VER="0.3.0"
+CALDP_VER="0.2.0"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20201208_DRZ_final"
 # this is the tag that the image will have in AWS ECR
 CALDP_IMAGE_TAG="latest"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,7 +51,7 @@ variable lt_ebs_type {
   default = {
     "-sb" = "gp2"
     "-dev" = "gp2"
-    "-test" = "gp2"
+    "-test" = "gp3"
     "-ops" = "gp2"
   }
 }
@@ -64,7 +64,7 @@ variable lt_ebs_iops {
   default = {
     "-sb" = 0
     "-dev" = 0
-    "-test" = 0
+    "-test" = 3000
     "-ops" = 0
   }
 }
@@ -77,13 +77,10 @@ variable lt_ebs_throughput {
   default = {
     "-sb" = null
     "-dev" = null
-    "-test" = null
+    "-test" = 250
     "-ops" = null
   }
 }
-
-
-
 
 variable ce_max_vcpu {
   description = "the max allowed vCPUs in the compute environment"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,11 +60,12 @@ variable lt_ebs_iops {
   description = "the provisioned iops of the ebs."
   type = map(number)
   # only valid for gp3, io1, io2 volumes
+  # gp2 does not like null; it makes the compute env turn to invalid
   default = {
-    "-sb" = null
-    "-dev" = null
-    "-test" = null
-    "-ops" = null
+    "-sb" = 0
+    "-dev" = 0
+    "-test" = 0
+    "-ops" = 0
   }
 }
 


### PR DESCRIPTION
fixing a quick bug with the env-specific EBS settings;

these can potentially be deprecated as env-specific in the future but until we're done with performance testing there's value in leaving open the possibility of IOPS changes