### PR TITLE
Pin lambda_job_predict version

### DIFF
--- a/terraform/lambda_job_predict.tf
+++ b/terraform/lambda_job_predict.tf
@@ -21,6 +21,7 @@ resource "docker_registry_image" "calcloud_predict_model" {
 
 module "lambda_function_container_image" {
   source = "terraform-aws-modules/lambda/aws"
+  version = "~> 1.43.0"
   function_name = "calcloud-job-predict${local.environment}"
   description   = "pretrained neural networks for predicting job resource requirements (memory bin and max execution time)"
 


### PR DESCRIPTION
Pinned lambda_job_predict module version back to 1.43.0 same as all other lambdas.  This is an untested regression from 1.44.0.