### PR TITLE
actually use the max cpu var and fix crds contexts

### DIFF
--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -125,7 +125,7 @@ resource "aws_batch_compute_environment" "calcloud" {
     subnets             = local.batch_subnet_ids
     security_group_ids  = local.batch_sgs
     instance_type = ["optimal"]
-    max_vcpus = 128
+    max_vcpus = lookup(var.ce_max_vcpu, local.environment, 64)
     min_vcpus = 0
     desired_vcpus = 0
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -88,8 +88,8 @@ variable ce_max_vcpu {
   default = {
     "-sb" = 64
     "-dev" = 128
-    "-test" = 128
-    "-ops" = 128
+    "-test" = 512
+    "-ops" = 512
   }
 }
 
@@ -99,7 +99,7 @@ variable crds_context {
   default = {
     "-sb" = "hst_0866.pmap"
     "-dev" = "hst_0866.pmap"
-    "-test" = "hst_0866.pmap"
+    "-test" = "hst_0869.pmap"
     "-ops" = "hst_0869.pmap"
   }
 }
@@ -109,7 +109,7 @@ variable crds_bucket {
   default = {
     "-sb" = "test"
     "-dev" = "test"
-    "-test" = "test"
+    "-test" = "ops"
     "-ops" = "ops"
   }
 }


### PR DESCRIPTION
* change max cpu in test to 512 and actually use it in the compute environment
* updates to default crds contexts
