### PR TITLE
Improved blackboard exit reason string

### DIFF
--- a/lambda/blackboard/scrape_batch.py
+++ b/lambda/blackboard/scrape_batch.py
@@ -63,7 +63,13 @@ def lambda_handler(event, context):
                         # if the job hasn't started container doesn't seem to be in the keys
                         container = j.get("container", {})
                         exitCode = container.get("exitCode", 0)
-                        exitReason = container.get("reason", j.get("statusReason", "None"))
+
+                        containerReason = container.get("reason", "None")
+                        jobReason = j.get("statusReason", "None")
+                        if jobReason.startswith("Essential"):
+                            exitReason = containerReason[:120] + "; " + jobReason[:120]
+                        else:
+                            exitReason = container.get("reason", j.get("statusReason", "None"))[:255]
 
                         dataset = j["jobName"].split("-")[-1]
 

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -179,7 +179,8 @@ data "aws_ecr_image" "caldp_latest" {
 
 # ------------------------------------------------------------------------------------------
 
-# 2G -----------------  also reserve 128M per 1G for Batch ECS + STScI overheads
+# Env setting to simulate caught errors:
+#      {"name": "CALDP_SIMULATE_ERROR", "value": "32"}
 
 resource "aws_batch_job_definition" "job_def" {
   name                 = "calcloud-jobdef-${local.ladder[count.index].name}${local.environment}"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -13,6 +13,7 @@ locals {
 
        job_queues = join(",", aws_batch_job_queue.batch_queue[*].name)   # for env vars
 
+       # Reserving 128M/1024M for ECS overheads
        ladder = [
               { # -------------------------------------------------------------------
                 name : "02g",


### PR DESCRIPTION
Modified blackboard exit status to include both container and job statuswhen the job status starts with Essential (container in task exited).  Added/modified a couple Terraform comments.