### PR TITLE
increment deploy versions in prep for releases

### DIFF
--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,8 +3,8 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.1"
-CALDP_VER="0.2.2"
+CALCLOUD_VER="0.4.2"
+CALDP_VER="0.2.3"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210323_CAL_final"
 CSYS_VER="CALDP_20210323"
 # this is the tag that the image will have in AWS ECR

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -45,5 +45,5 @@ output s3_output_bucket {
 }
 
 output crds_context {
-  value = var.crds_context[local.environment]
+  value = lookup(var.crds_context, local.environment, var.crds_context["-sb"])
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -88,7 +88,7 @@ variable ce_max_vcpu {
   default = {
     "-sb" = 64
     "-dev" = 128
-    "-test" = 512
+    "-test" = 1024
     "-ops" = 512
   }
 }


### PR DESCRIPTION
* incremented calcloud and caldp version in prep for release.
* quickfix for an issue with the crds_context output value
* upped the default test CPU allocation