### PR TITLE
Add local.environment where missing from cloudwatch event rule names

### DIFF
--- a/terraform/lambda_batch_events.tf
+++ b/terraform/lambda_batch_events.tf
@@ -54,7 +54,7 @@ module "calcloud_lambda_batchEvents" {
 
 # the event rule for this lambda/cloudwatch interaction is AWS failure events
 resource "aws_cloudwatch_event_rule" "batch" {
-  name = "capture-batch-failure-events"
+  name = "capture-batch-failure-events${local.environment}"
   description = "capture AWS Batch failures to send to lambda for evaluation"
 
   event_pattern = <<EOF

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -56,7 +56,7 @@ module "calcloud_lambda_blackboard" {
 
 # for cron-like schedule of blackboard lambda
 resource "aws_cloudwatch_event_rule" "every_five_minutes" {
-  name                = "every-five-minutes"
+  name                = "every-five-minutes${local.environment}"
   description         = "Fires every five minutes"
   schedule_expression = "rate(5 minutes)"
 }

--- a/terraform/lambda_refresh_cache.tf
+++ b/terraform/lambda_refresh_cache.tf
@@ -4,7 +4,7 @@ module "calcloud_lambda_refresh_cache_submit" {
 
   function_name = "calcloud-fileshare-refresh_cache_submit${local.environment}"
   description   = "submits refresh cache operations"
-  # the path is relative to the path inside the lambda env, not in the local filesystem. 
+  # the path is relative to the path inside the lambda env, not in the local filesystem.
   handler       = "refresh_cache_submit.lambda_handler"
   runtime       = "python3.6"
   publish       = false
@@ -37,7 +37,7 @@ module "calcloud_lambda_refresh_cache_submit" {
   attach_tracing_policy = false
   attach_async_event_policy = false
   # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation. 
+  # will need to parametrize when ITSD takes over role creation.
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_refreshCacheSubmit_role.value
 
@@ -52,7 +52,7 @@ module "calcloud_lambda_refresh_cache_submit" {
 }
 
 resource "aws_cloudwatch_event_rule" "refresh_cache_schedule" {
-  name                = "refresh-cache-scheduler"
+  name                = "refresh-cache-scheduler${local.environment}"
   description         = "Fires every five minutes"
   schedule_expression = "rate(5 minutes)"
 }

--- a/terraform/lambda_refresh_cache_logging.tf
+++ b/terraform/lambda_refresh_cache_logging.tf
@@ -52,7 +52,7 @@ module "calcloud_lambda_refresh_cache_logs" {
 
 # the event rule for this lambda/cloudwatch interaction is AWS failure events
 resource "aws_cloudwatch_event_rule" "refresh_cache_logs" {
-  name = "capture-refresh-cache-operations"
+  name = "capture-refresh-cache-operations${local.environment}"
   description = "capture file share refresh cache operations to track and evaluate them in log stream"
 
   event_pattern = <<EOF


### PR DESCRIPTION
Tested this with a simulated error proving that the batch failure event still works.

NOTE:  requires adding "*" to cloudwatch event rule name constraints in IAM hst_reprocessing_admin_role.