### PR TITLE
calcloud-240 canceled jobs send error message

### DIFF
--- a/calcloud/batch.py
+++ b/calcloud/batch.py
@@ -78,6 +78,23 @@ def _list_jobs_iterator(queue, status, PageSize=10, client=None):
     return paginator.paginate(jobQueue=queue, jobStatus=status, PaginationConfig={"PageSize": PageSize})
 
 
+def describe_job(job_id, client=None):
+    """Return the description from describe_jobs() for `job_id` or None."""
+    client = client or get_default_client()
+    response = client.describe_jobs(jobs=[job_id])
+    jobs = response["jobs"]
+    if len(jobs):
+        return jobs[0]
+    else:
+        return
+
+
+def get_job_name(job_id, client=None):
+    """Return the name of job `job_id` which ATM is nominally ipppssoot."""
+    description = describe_job(job_id, client)
+    return description["jobName"]
+
+
 def _format_job_listing(job):
     revised = dict(job)
     _format_seconds(revised, "createdAt")

--- a/calcloud/batch.py
+++ b/calcloud/batch.py
@@ -91,6 +91,7 @@ def describe_job(job_id, client=None):
 
 def get_job_name(job_id, client=None):
     """Return the name of job `job_id` which ATM is nominally ipppssoot."""
+    job_id = job_id.replace("_", "-")  # messages use _
     description = describe_job(job_id, client)
     return description["jobName"]
 
@@ -136,7 +137,7 @@ def _get_outputter(output_format):
     return func
 
 
-def terminate_job(job_id, ipppssoot, reason=None, client=None):
+def terminate_job(job_id, reason=None, client=None):
     """Terminate Batch job `job_id` associated with `ipppsssoot` using Batch `client`.
 
     Return True IFF client.terminate_job() call terminates a job.
@@ -145,7 +146,7 @@ def terminate_job(job_id, ipppssoot, reason=None, client=None):
     job_id = job_id.replace("_", "-")  # undo hacking needed to make it a simple messsage id
     response = client.terminate_job(jobId=job_id, reason=reason)
     print(response)
-    print(f"terminate response: {response['ResponseMetadata']['HTTPStatusCode']}: {job_id} - {ipppssoot}")
+    print(f"terminate response: {response['ResponseMetadata']['HTTPStatusCode']}: {job_id}")
     return response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 

--- a/calcloud/log.py
+++ b/calcloud/log.py
@@ -60,6 +60,7 @@ import sys
 import os
 import logging
 import pprint
+import contextlib
 
 DEFAULT_VERBOSITY_LEVEL = 50
 
@@ -345,6 +346,18 @@ def divider(name="", char="-", n=75, func=info, **keys):
         func(char * n2, name, char * n2, **keys)
     else:
         func(char * n, **keys)
+
+
+# ===================================================================
+
+
+@contextlib.contextmanager
+def trap_exception(*args):
+    """Print a message and continue on exception inside with-block."""
+    try:
+        yield
+    except Exception as exc:
+        info("Trapped exception", " ".join(args), "was:", exc)
 
 
 # ===================================================================

--- a/calcloud/plan.py
+++ b/calcloud/plan.py
@@ -137,12 +137,8 @@ def _get_environment(job_resources, memory_retries):
             "Final bin index",
             final_bin,
         )
-
         job_definition = job_defs[final_bin]
-        log.info("Selected job definition", job_definition)
-
         job_queue = job_queues[final_bin]
-        log.info("Selected job queue", job_queue)
     else:
         log.info("No higher memory job definition for", job_resources.ipppssoot, "after", memory_retries)
         raise AllBinsTriedQuit("No higher memory job definition for", job_resources.ipppssoot, "after", memory_retries)
@@ -174,7 +170,7 @@ def _planner(ipppssoots_file, output_bucket=s3.DEFAULT_BUCKET, input_path=s3.DEF
             continue
         for ipst in line.split():
             print(
-                tuple(get_plan(ipst, output_bucket, input_path, retries))
+                tuple(get_plan(ipst, "s3://" + output_bucket, "s3://" + input_path, retries))
             )  # Drop type to support literal_eval() vs. eval()
 
 

--- a/calcloud/s3.py
+++ b/calcloud/s3.py
@@ -47,7 +47,7 @@ def get_default_client():
     return DEFAULT_S3_CLIENT
 
 
-DEFAULT_BUCKET = os.environ.get("S3_PROCESSING_BUCKET", "s3://calcloud-UNDEFINED-bucket")
+DEFAULT_BUCKET = "s3://" + os.environ.get("BUCKET", "calcloud-UNDEFINED-bucket")
 
 MAX_LIST_OBJECTS = 10 ** 7
 

--- a/lambda/JobDelete/delete_handler.py
+++ b/lambda/JobDelete/delete_handler.py
@@ -1,26 +1,28 @@
 """This lambda handles job terminations based on cancel-all or cancel-ipppssoot
 S3 trigger messages.
 
-For cancel-all,  the lambda first lists all error and terminated messages,  then
-iterates through them issuing cancel-ipppssoot messages to trigger individual
-lambdas to do the primary cancellation work.
+For cancel-all,  the lambda first determines the job id's of all jobs in a killable
+state,  then broadcasts the cancel-job_id form of single job kill message.
 
-When an individual cancel-ipppssoot message is processed:
+For cancel-job_id,  the lambda determines the ipppssoot from the job name,  kills
+the job,  and adjusts messages and the control file based on the ipppssoot.
 
-1. The job's control metadata "terminated" flag is set to True
-2. The batch.terminate_job function is called using the job_id in the control metadata
+For cancel-ipppssoot,  the lambda determines the job_id from the control file,  kills
+the job,  and adjusts messages and the control file based on the ipppssoot.
+
+1. The job's control metadata "terminated" flag is set to True.
+2. The batch.terminate_job function is called.
 3. All messages for the ipppssoot are deleted.
 4. The terminated-ipppssoot message is sent.
 
 The control metadata of the cancelled ipppssoot is updated,  not deleted, in
 order to short circuit memory based retries on subsequent rescues.
 """
+
 from calcloud import batch
 from calcloud import io
 from calcloud import s3
-from calcloud import hst
-
-CLEANUP_TYPES = ["processing", "submit", "processed", "error"]
+from calcloud import log
 
 
 def lambda_handler(event, context):
@@ -32,39 +34,24 @@ def lambda_handler(event, context):
     if ipst == "all":
         # Delete exactly the cancel-all message,  not every ipppssoot
         comm.messages.delete_literal("cancel-all")
-
-        # Define jobs as anything with a control metadata file
-        ipppssoots = comm.xdata.listl("all")
-        comm.messages.broadcast("cancel", ipppssoots)
-
-        # Pick up any orphan jobs by listing them all. These deletes compete with ipppssoots
+        # Cancel all jobs in a killable state broadcasting cancel over job_ids
         job_ids = batch.get_job_ids()
         comm.messages.broadcast("cancel", job_ids)
+    elif batch.JOB_ID_RE.match(ipst):  # kill one job
+        comm.messages.delete(f"cancel-{ipst}")
+        job_id, ipst = ipst.replace("_", "-"), "unknown"
+        metadata = dict(job_id=job_id, cancel_type="job_id")
+        ipst = batch.get_job_name(job_id)  # ipst or "unknown"
 
-    elif hst.IPPPSSOOT_RE.match(ipst):
-        # Terminate a single ipppssoot
-        try:
-            metadata = comm.xdata.get(ipst)
+        print("Cancelling ipppssoot", ipst, "job_id", job_id)
+
+        with log.trap_exception("updating control file for", ipst, "job_id", job_id):
             metadata["terminated"] = True
             comm.xdata.put(ipst, metadata)
-        except Exception as exc:
-            print("Exception updating control file for", ipst, "was", exc)
-
-        try:
-            batch.terminate_job(metadata["job_id"], ipst, "Operator cancelled")
-        except Exception as exc:
-            print("Exception terminating", ipst, "was", exc)
-
-        try:
+        with log.trap_exception("handling messages for", ipst, "job_id", job_id):
             comm.messages.delete(f"all-{ipst}")
-            comm.messages.put(f"terminated-{ipst}")
-        except Exception as exc:
-            print("Exception updating messages for", ipst, "to terminated was", exc)
-    elif batch.JOB_ID_RE.match(ipst):
-        try:
-            batch.terminate_job(ipst, ipst, "cancel-all terminated job directly")
-        except Exception as exc:
-            print("Exception terminating", ipst, "was", exc)
-        comm.messages.delete(f"cancel-{ipst}")
+            comm.messages.put(f"terminated-{ipst}", "cancel lambda " + comm.bucket)
+        with log.trap_exception("terminating", ipst, "job_id", job_id):
+            batch.terminate_job(job_id, ipst, "Operator cancelled")
     else:
-        print("Bad cancel ID", ipst)
+        raise ValueError("Bad cancel ID", ipst)

--- a/lambda/JobDelete/delete_handler.py
+++ b/lambda/JobDelete/delete_handler.py
@@ -23,6 +23,7 @@ from calcloud import batch
 from calcloud import io
 from calcloud import s3
 from calcloud import log
+from calcloud import hst
 
 
 def lambda_handler(event, context):
@@ -37,21 +38,34 @@ def lambda_handler(event, context):
         # Cancel all jobs in a killable state broadcasting cancel over job_ids
         job_ids = batch.get_job_ids()
         comm.messages.broadcast("cancel", job_ids)
-    elif batch.JOB_ID_RE.match(ipst):  # kill one job
-        comm.messages.delete(f"cancel-{ipst}")
-        job_id, ipst = ipst.replace("_", "-"), "unknown"
-        metadata = dict(job_id=job_id, cancel_type="job_id")
-        ipst = batch.get_job_name(job_id)  # ipst or "unknown"
-
-        print("Cancelling ipppssoot", ipst, "job_id", job_id)
-
-        with log.trap_exception("updating control file for", ipst, "job_id", job_id):
+    elif batch.JOB_ID_RE.match(ipst):
+        job_id, ipst = ipst, "unknown"  # kill one job, ipst = job_id
+        print("Cancelling job_id", job_id)
+        comm.messages.delete_literal(f"cancel-{job_id}")
+        with log.trap_exception("Handling messages + control for", job_id):
+            ipst = batch.get_job_name(job_id)
+            print("Handlign messages and control for", ipst)
+            comm.messages.delete(f"all-{ipst}")
+            comm.messages.put(f"terminated-{ipst}", "cancel lambda " + bucket_name)
+            try:
+                metadata = comm.xdata.get(ipst)
+            except comm.xdata.client.exceptions.NoSuchKeyError:
+                metadata = dict(job_id=job_id, cancel_type="job_id")
             metadata["terminated"] = True
             comm.xdata.put(ipst, metadata)
-        with log.trap_exception("handling messages for", ipst, "job_id", job_id):
-            comm.messages.delete(f"all-{ipst}")
-            comm.messages.put(f"terminated-{ipst}", "cancel lambda " + comm.bucket)
-        with log.trap_exception("terminating", ipst, "job_id", job_id):
-            batch.terminate_job(job_id, ipst, "Operator cancelled")
+        # Do last so terminate flag is set if possible.
+        print("Terminating", job_id)
+        batch.terminate_job(job_id, "Operator cancelled")
+    elif hst.IPPPSSOOT_RE.match(ipst):  # kill one ipppssoot
+        print("Cancelling ipppssoot", ipst)
+        comm.messages.delete(f"all-{ipst}")
+        comm.messages.put(f"terminated-{ipst}", "cancel lambda " + bucket_name)
+        metadata = comm.xdata.get(ipst)
+        metadata["terminated"] = True
+        comm.xdata.put(ipst, metadata)
+        job_id = metadata["job_id"]
+        with log.trap_exception("Terminating", job_id):
+            print("Terminating", job_id)
+            batch.terminate_job(job_id, "Operator cancelled")
     else:
         raise ValueError("Bad cancel ID", ipst)

--- a/lambda/JobPredict/predict_handler.py
+++ b/lambda/JobPredict/predict_handler.py
@@ -158,6 +158,7 @@ def lambda_handler(event, context):
     MEMORY REGRESSION: A third regression model is used to estimate the actual value of memory needed for the job. This is mainly for the purpose of logging/future analysis and is not currently being used for allocating memory in calcloud jobs.
     """
     bucket_name = event["Bucket"]
+
     key = event["Key"]
     ipppssoot = event["Ipppssoot"]
     prep = Preprocess(ipppssoot, bucket_name, key)

--- a/lambda/batch_events/batch_event_handler.py
+++ b/lambda/batch_events/batch_event_handler.py
@@ -39,6 +39,8 @@ def lambda_handler(event, context):
     exit_code = container.get("exitCode", "undefined")
     exit_reason = exit_codes.explain(exit_code) if exit_code != "undefined" else exit_code
 
+    io.reject_cross_env_bucket(bucket)
+
     comm = io.get_io_bundle(bucket)
 
     metadata = comm.xdata.get(ipppssoot)
@@ -76,6 +78,7 @@ def lambda_handler(event, context):
             print("Automatic CannotInspectContainer retries for", ipppssoot, "exhausted at", metadata["retries"])
     elif status_reason.startswith("Operator cancelled"):
         print("Operator cancelled job", job_id, "for", ipppssoot, "no automatic retry.")
+        continuation_msg = "terminated-" + ipppssoot
     else:
         print("Failure for", ipppssoot, "no automatic retry for", combined_reason)
 
@@ -83,4 +86,4 @@ def lambda_handler(event, context):
     print(metadata)
     comm.xdata.put(ipppssoot, metadata)
     comm.messages.delete("all-" + ipppssoot)
-    comm.messages.put(continuation_msg)
+    comm.messages.put({continuation_msg: "batch failure event handler " + bucket})

--- a/terraform/lambda_batch_events.tf
+++ b/terraform/lambda_batch_events.tf
@@ -41,11 +41,10 @@ module "calcloud_lambda_batchEvents" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
 
-  environment_variables = {
-    JOBQUEUES=local.job_queues,
+  environment_variables = merge(local.common_env_vars, {
     MAX_MEMORY_RETRIES="4",
     MAX_INSPECT_RETRIES="4"
-  }
+  })
 
   tags = {
     Name = "calcloud-job-events${local.environment}"

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -42,12 +42,8 @@ module "calcloud_lambda_blackboard" {
   # lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
   lambda_role = data.aws_ssm_parameter.lambda_blackboard_role.value
 
-  environment_variables = {
-    # comma delimited list of job queues, because batch can only list jobs per queue
-    JOBQUEUES=local.job_queues
-    BUCKET=aws_s3_bucket.calcloud.id
-    FILESHARE=data.aws_ssm_parameter.file_share_arn.value
-  }
+  environment_variables = merge(local.common_env_vars, {
+  })
 
   tags = {
     Name = "calcloud-job-blackboard${local.environment}"

--- a/terraform/lambda_broadcast.tf
+++ b/terraform/lambda_broadcast.tf
@@ -3,8 +3,8 @@ module "calcloud_lambda_broadcast" {
   version = "~> 1.43.0"
 
   function_name = "calcloud-broadcast${local.environment}"
-  description   = "Broadcasts the specified ipppssoot (must be in error state) by deleting all outputs and messages and re-placing."
-  # the path is relative to the path inside the lambda env, not in the local filesystem. 
+  description   = "Broadcasts the specified message type across a list of job_ids or ippppssoots."
+  # the path is relative to the path inside the lambda env, not in the local filesystem.
   handler       = "broadcast_handler.lambda_handler"
   runtime       = "python3.6"
   publish       = false
@@ -36,12 +36,15 @@ module "calcloud_lambda_broadcast" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  
+
   # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation. 
+  # will need to parametrize when ITSD takes over role creation.
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_broadcast_role.value
-  
+
+  environment_variables = merge(local.common_env_vars, {
+  })
+
   tags = {
     Name = "calcloud-broadcast${local.environment}"
   }
@@ -55,4 +58,3 @@ resource "aws_lambda_permission" "allow_bucket_broadcastLambda" {
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
 }
-

--- a/terraform/lambda_job_clean.tf
+++ b/terraform/lambda_job_clean.tf
@@ -41,9 +41,8 @@ module "calcloud_lambda_cleanJob" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_cleanup_role.value
 
-  environment_variables = {
-    JOBQUEUES=local.job_queues,
-  }
+  environment_variables = merge(local.common_env_vars, {
+  })
 
   tags = {
     Name = "calcloud-job-clean${local.environment}"

--- a/terraform/lambda_job_delete.tf
+++ b/terraform/lambda_job_delete.tf
@@ -41,9 +41,8 @@ module "calcloud_lambda_deleteJob" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_delete_role.value
 
-  environment_variables = {
-    JOBQUEUES=local.job_queues
-  }
+  environment_variables = merge(local.common_env_vars, {
+  })
 
   tags = {
     Name = "calcloud-job-delete${local.environment}"

--- a/terraform/lambda_job_predict.tf
+++ b/terraform/lambda_job_predict.tf
@@ -47,6 +47,9 @@ module "lambda_function_container_image" {
   # existing role for the lambda
   lambda_role = data.aws_ssm_parameter.lambda_predict_role.value
 
+  environment_variables = merge(local.common_env_vars, {
+  })
+
   tags = {
     Name = "calcloud-job-predict${local.environment}"
   }

--- a/terraform/lambda_job_rescue.tf
+++ b/terraform/lambda_job_rescue.tf
@@ -41,11 +41,9 @@ module "calcloud_lambda_rescueJob" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_rescue_role.value
 
-  environment_variables = {
-    JOBDEFINITIONS = local.job_definitions,
-    JOBQUEUES = local.job_queues,
-    JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn
-  }
+  environment_variables = merge(local.common_env_vars, {
+      JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,
+  })
 
   tags = {
     Name = "calcloud-job-rescue${local.environment}"

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -42,11 +42,9 @@ module "calcloud_lambda_submit" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
 
-  environment_variables = {
-    JOBDEFINITIONS = local.job_definitions,
-    JOBQUEUES = local.job_queues,
-    JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn
-  }
+  environment_variables = merge(local.common_env_vars, {
+      JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,
+  })
 
   tags = {
     Name = "calcloud-job-submit${local.environment}"

--- a/terraform/lambda_refresh_cache.tf
+++ b/terraform/lambda_refresh_cache.tf
@@ -41,10 +41,8 @@ module "calcloud_lambda_refresh_cache_submit" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_refreshCacheSubmit_role.value
 
-  environment_variables = {
-    # comma delimited list of job queues, because batch can only list jobs per queue
-    FILESHARE=data.aws_ssm_parameter.file_share_arn.value
-  }
+  environment_variables = merge(local.common_env_vars, {
+  })
 
   tags = {
     Name = "calcloud-fileshare-refresh_cache_submits${local.environment}"

--- a/terraform/lambda_refresh_cache_logging.tf
+++ b/terraform/lambda_refresh_cache_logging.tf
@@ -41,9 +41,8 @@ module "calcloud_lambda_refresh_cache_logs" {
   # for now this role was created by hand in the console, it is not terraform managed
   lambda_role = data.aws_ssm_parameter.lambda_cloudwatch_role.value
 
-#   environment_variables = {
-#     JOBQUEUES=local.job_queues
-#   }
+  environment_variables = merge(local.common_env_vars, {
+  })
 
   tags = {
     Name = "calcloud-fileshare-refresh_cache_logs${local.environment}"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -88,4 +88,13 @@ locals {
 
        # code is cleaner to put this in locals
        crds_context = lookup(var.crds_context, local.environment, var.crds_context["-sb"])
+
+       # environment variables supplied to all lambdas,  see also AWS batch job definition
+       common_env_vars = {
+           CALCLOUD_ENVIRONMENT = local.environment,
+           JOBDEFINITIONS = local.job_definitions,
+           JOBQUEUES = local.job_queues,
+           FILESHARE=data.aws_ssm_parameter.file_share_arn.value,
+           BUCKET=aws_s3_bucket.calcloud.id,
+       }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -47,3 +47,7 @@ output s3_output_bucket {
 output crds_context {
   value = lookup(var.crds_context, local.environment, var.crds_context["-sb"])
 }
+
+output common_env_vars {
+  value = local.common_env_vars
+}

--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/terraform/remote_state.tf
+++ b/terraform/remote_state.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "s3" {}
-}


### PR DESCRIPTION
Refactors clean-all lambda and adds "rejection" logic to prevent the batch fail events from 
being processed on all strings.

Extensive refactor of clean lambda to cancel-all based on killable job ids
only, no longer based on ipppssoot control file.  This avoids competing job
kills between job_id-based (required to kill orphan jobs) and
ipppssoot-based (mentioned in control file) and also preserves completed
jobs.

Refactored lambda environments to largely use local.common_env_vars ensuring that BUCKET
is defined in all lambdas.

Added "rejection logic" to kill the batch event handler when the bucket obtained from
the failed job does not match the BUCKET the lambda  was built with.  This stops the
cross-environment event contamination where a secondary environment was processing the
same failure events as the development environment resulting in extraneous error
messages.

Improve signature and documentation for S3Io.put and MessageIo.put, adding the
simple/natural forms S3Io.put(msg_type, payload) and MessageIo.put(msg_type,
payload).  Make signatures of super and subclass put() comply with Liskov
Substitution Principle.

Added payloads to error/terminate messages to indicate which lambda they came from.