### PR TITLE
CC249/refresh-cache-every-5min

### DIFF
--- a/lambda/refreshCacheSubmit/refresh_cache_submit.py
+++ b/lambda/refreshCacheSubmit/refresh_cache_submit.py
@@ -6,8 +6,8 @@ def lambda_handler(event, context):
     gateway = boto3.client("storagegateway", config=common.retry_config)
     # we only get two concurrent refresh cache operations, but we'll use them both to get some parallelization
     # refresh every 5 minutes via EventBridge
-    refresh_1 = ["/messages/", "/inputs/", "/control/"]
-    refresh_2 = ["/outputs/", "/blackboard/", "/crds_env_vars/"]
+    refresh_1 = ["/messages/", "/inputs/", "/blackboard/"]
+    refresh_2 = ["/outputs/", "/control/", "/crds_env_vars/"]
 
     print(event)
 


### PR DESCRIPTION
CALCLOUD-249: refresh each s3 prefix every time refresh_cache_submit lambda is invoked by EventBridge (set to every 5 mins)