### PR TITLE
Added message cleanup to submit lambda timeout.

### DIFF
--- a/calcloud/lambda_submit.py
+++ b/calcloud/lambda_submit.py
@@ -13,6 +13,7 @@ handlers for more information on how jobs are initiated and
 retried.
 """
 import time
+import os
 
 from . import plan
 from . import submit
@@ -81,8 +82,10 @@ def wait_for_inputs(comm, ipppssoot):
     Each iteration,  check for the S3 message files which trigger submissions and abort if none
     are found.
 
-    Eventually after 15 min (default) the lambda will die if it's still waiting.
+    Eventually after 15 min (default) the lambda will die if it's still waiting.  Instead,  if
+    it's still running at 14 minutes an exception is raised to force cleanup and send and error message.
     """
+    poll_seconds, seconds_to_fail = 30, int(os.environ["SUBMIT_TIMEOUT"])
     input_tarball, memory_modeling = [], []
     while not input_tarball or not memory_modeling:
         input_tarball = comm.inputs.listl(f"{ipppssoot}.tar.gz")
@@ -93,7 +96,12 @@ def wait_for_inputs(comm, ipppssoot):
             )
         if not input_tarball or not memory_modeling:
             print(
-                f"Waiting for inputs for {ipppssoot}. input_tarball={input_tarball}  memory_modeling={memory_modeling}"
+                f"Waiting for inputs for {ipppssoot} time remaining={seconds_to_fail}. input_tarball={len(input_tarball)}  memory_modeling={len(memory_modeling)}"
             )
-            time.sleep(30)
+            time.sleep(poll_seconds)
+            seconds_to_fail -= poll_seconds
+            if seconds_to_fail <= 0:
+                raise CalcloudInputsFailure(
+                    f"Wait for inputs for {ipppssoot} timeout, aborting submission.  input_tarball={len(input_tarball)}  memory_modeling={len(memory_modeling)}"
+                )
     print(f"Inputs for {ipppssoot} found.")

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -9,7 +9,7 @@ module "calcloud_lambda_submit" {
   handler       = "s3_trigger_handler.lambda_handler"
   runtime       = "python3.6"
   publish       = false
-  timeout       = 900
+  timeout       = 15*60   # see also SUBMIT_TIMEOUT below;  this is the AWS timeout, calcloud error handling may not occur
   cloudwatch_logs_retention_in_days = local.lambda_log_retention_in_days
 
   source_path = [
@@ -44,7 +44,8 @@ module "calcloud_lambda_submit" {
 
   environment_variables = merge(local.common_env_vars, {
       JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,
-  })
+      SUBMIT_TIMEOUT = 14*60,  # leave some room for polling jitter, 14 min vs  15 min above
+  })                           # this is our timeout so error handling / cleanup should occur
 
   tags = {
     Name = "calcloud-job-submit${local.environment}"


### PR DESCRIPTION
Added timeout/exception to submit lambda prior to AWS lambda timeout to
ensure message cleanup and error status.  AWS lambda timeout and CALCLOUD wait
timeout are configurable in lambda_job_submit.tf.  It's important for
calcloud to timeout and cleanup before the lambda actually fails for AWS so that
appropriate error handling occurs.