### PR TITLE
base image and default crds context updates

### DIFF
--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,9 +3,9 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.13"
-CALDP_VER="0.2.8"
-CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210415_CAL_final"
+CALCLOUD_VER="0.4.14"
+CALDP_VER="0.2.9"
+CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210505_CAL_final"
 
 # this is the tag that the image will have in AWS ECR
 CALDP_IMAGE_TAG="latest"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -99,8 +99,8 @@ variable crds_context {
   default = {
     "-sb" = "hst_0866.pmap"
     "-dev" = "hst_0866.pmap"
-    "-test" = "hst_0903.pmap"
-    "-ops" = "hst_0903.pmap"
+    "-test" = "hst_0910.pmap"
+    "-ops" = "hst_0910.pmap"
   }
 }
 


### PR DESCRIPTION
* updates default base image to CALDP_20210505_CAL_final
* updates default CRDS context to 0910 (ops)
* increments package versions in deploy script in anticipation of releases