### PR TITLE
quickfix for ebs volume on ops

### DIFF
--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,7 +3,7 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.13"
+CALCLOUD_VER="0.4.13-qf1"
 CALDP_VER="0.2.8"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210415_CAL_final"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,7 +52,7 @@ variable lt_ebs_type {
     "-sb" = "gp2"
     "-dev" = "gp2"
     "-test" = "gp3"
-    "-ops" = "gp2"
+    "-ops" = "gp3"
   }
 }
 
@@ -65,7 +65,7 @@ variable lt_ebs_iops {
     "-sb" = 0
     "-dev" = 0
     "-test" = 3000
-    "-ops" = 0
+    "-ops" = 3000
   }
 }
 
@@ -78,7 +78,7 @@ variable lt_ebs_throughput {
     "-sb" = null
     "-dev" = null
     "-test" = 250
-    "-ops" = null
+    "-ops" = 250
   }
 }
 


### PR DESCRIPTION
* uses correct EBS settings on ops (gp3, 3000iops, 250 throughput)