### PR TITLE
Add clean-ingested

### DIFF
--- a/calcloud/io.py
+++ b/calcloud/io.py
@@ -284,6 +284,9 @@ class MessageIo(JsonIo):
     It can operate on all types of messages for all ipppssoots,
     e.g. 'all'.
 
+    A special case exists for 'clean-ingested' where 'ingested' corresponds to every
+    ipppssoot which already as an 'ingested-<ipppssoot>' message.
+
     >>> comm = get_io_bundle()
 
     put() enables sending a message or sequence of messages which should be fully specified
@@ -311,6 +314,16 @@ class MessageIo(JsonIo):
     ['cancel-lcw303cjq', 'error-lcw303cjq', 'processed-lcw303cjq']
 
     The "all" or "" messages expand to all existing messages:
+
+    >>> comm.messages.delete("all");
+
+    A special case exists for 'clean-ingested' where 'ingested' corresponds to every
+    ipppssoot which already as an 'ingested-<ipppssoot>' message.  This is a limited
+    special case which may not support all methods and use cases.
+
+    >>> comm.messages.put("clean-ingested")
+    >>> comm.messages.listl()
+    ['clean-ingested']
 
     >>> comm.messages.delete("all");
     >>> comm.messages.listl()

--- a/lambda/JobClean/clean_handler.py
+++ b/lambda/JobClean/clean_handler.py
@@ -15,11 +15,19 @@ def lambda_handler(event, context):
     comm = io.get_io_bundle(bucket_name)
 
     if ipst == "all":
-        print("Cleaning all;  removing all job resources (S3 files).")
+        print("Cleaning all datasets;  removing all job resources (S3 files).")
 
         comm.messages.delete_literal("clean-all")  # don't interpret all as existing ipppssoots
 
         cleanup_ids = comm.ids("all")
+
+        comm.messages.broadcast("clean", cleanup_ids)
+    elif ipst == "ingested":  # a variation of "all" restricted to datasets with an ingest message
+        print("Cleaning all ingested datasets;  removing all job resources (S3 files).")
+
+        comm.messages.delete_literal("clean-ingested")  # don't interpret "ingested"
+
+        cleanup_ids = comm.messages.ids("ingested")
 
         comm.messages.broadcast("clean", cleanup_ids)
     else:


### PR DESCRIPTION
Added a clean-ingested mode which restricts the datasets cleaned to those which have an ingested message;  in other respects it is similar to clean-all.

Potentially this could simplify / asbstract a little more by collapsing the all and ingested handlers,  but the "find ids" function varies so it's not quite as easy as it first appears.