### PR TITLE
every ssm param explicitly nonsensitive (supporting upgrade to terraform 0.15.4)

### DIFF
--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -52,7 +52,7 @@ resource "aws_launch_template" "hstdp" {
   name = "calcloud-hst-worker${local.environment}"
   description             = "Template for cluster worker nodes updated to limit stopped container lifespan"
   ebs_optimized           = "false"
-  image_id                = data.aws_ssm_parameter.batch_ami_id.value
+  image_id                = nonsensitive(data.aws_ssm_parameter.batch_ami_id.value)
   update_default_version = true
   tags                    = {
     "Name"         = "calcloud-hst-worker${local.environment}"
@@ -80,7 +80,7 @@ resource "aws_launch_template" "hstdp" {
             }
   }
   iam_instance_profile {
-    arn = data.aws_ssm_parameter.ecs_instance_role.value
+    arn = nonsensitive(data.aws_ssm_parameter.ecs_instance_role.value)
   }
   monitoring {
     enabled = true
@@ -115,11 +115,11 @@ resource "aws_batch_compute_environment" "compute_env" {
   count = 4
   compute_environment_name_prefix = "calcloud-hst-${local.ladder[count.index].name}${local.environment}"
   type = "MANAGED"
-  service_role = data.aws_ssm_parameter.batch_service_role.value
+  service_role = nonsensitive(data.aws_ssm_parameter.batch_service_role.value)
 
   compute_resources {
     allocation_strategy = "BEST_FIT"
-    instance_role = data.aws_ssm_parameter.ecs_instance_role.value
+    instance_role = nonsensitive(data.aws_ssm_parameter.ecs_instance_role.value)
     type = "EC2"
     bid_percentage = 0
     tags = {}
@@ -196,7 +196,7 @@ resource "aws_batch_job_definition" "job_def" {
       {"name": "CRDSBUCKET", "value": "${local.crds_bucket}"}
     ],
     "image": "${aws_ecr_repository.caldp_ecr.repository_url}:${data.aws_ecr_image.caldp_latest.image_tag}",
-    "jobRoleArn": "${data.aws_ssm_parameter.batch_job_role.value}",
+    "jobRoleArn": "${nonsensitive(data.aws_ssm_parameter.batch_job_role.value)}",
     "mountPoints": [],
     "resourceRequirements": [
         {"value" :  "${local.ladder[count.index].jd_memory}", "type" : "MEMORY"},

--- a/terraform/lambda_batch_events.tf
+++ b/terraform/lambda_batch_events.tf
@@ -36,10 +36,8 @@ module "calcloud_lambda_batchEvents" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_submit_role.value)
 
   environment_variables = merge(local.common_env_vars, {
     MAX_MEMORY_RETRIES="4",

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -36,11 +36,8 @@ module "calcloud_lambda_blackboard" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  # lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
-  lambda_role = data.aws_ssm_parameter.lambda_blackboard_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_blackboard_role.value)
 
   environment_variables = merge(local.common_env_vars, {
   })

--- a/terraform/lambda_broadcast.tf
+++ b/terraform/lambda_broadcast.tf
@@ -37,10 +37,7 @@ module "calcloud_lambda_broadcast" {
   attach_tracing_policy = false
   attach_async_event_policy = false
 
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_broadcast_role.value
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_broadcast_role.value)
 
   environment_variables = merge(local.common_env_vars, {
   })

--- a/terraform/lambda_job_clean.tf
+++ b/terraform/lambda_job_clean.tf
@@ -36,10 +36,8 @@ module "calcloud_lambda_cleanJob" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_cleanup_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_cleanup_role.value)
 
   environment_variables = merge(local.common_env_vars, {
   })

--- a/terraform/lambda_job_delete.tf
+++ b/terraform/lambda_job_delete.tf
@@ -36,10 +36,8 @@ module "calcloud_lambda_deleteJob" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_delete_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_delete_role.value)
 
   environment_variables = merge(local.common_env_vars, {
   })

--- a/terraform/lambda_job_predict.tf
+++ b/terraform/lambda_job_predict.tf
@@ -44,8 +44,8 @@ module "lambda_function_container_image" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  lambda_role = data.aws_ssm_parameter.lambda_predict_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_predict_role.value)
 
   environment_variables = merge(local.common_env_vars, {
   })

--- a/terraform/lambda_job_rescue.tf
+++ b/terraform/lambda_job_rescue.tf
@@ -36,10 +36,8 @@ module "calcloud_lambda_rescueJob" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_rescue_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_rescue_role.value)
 
   environment_variables = merge(local.common_env_vars, {
       JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -37,10 +37,8 @@ module "calcloud_lambda_submit" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_submit_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_submit_role.value)
 
   environment_variables = merge(local.common_env_vars, {
       JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,

--- a/terraform/lambda_refresh_cache.tf
+++ b/terraform/lambda_refresh_cache.tf
@@ -36,18 +36,16 @@ module "calcloud_lambda_refresh_cache_submit" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_refreshCacheSubmit_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_refreshCacheSubmit_role.value)
 
   environment_variables = merge(local.common_env_vars, {
-    FS_BLACKBOARD = data.aws_ssm_parameter.fs_blackboard_arn.value,
-    FS_CONTROL = data.aws_ssm_parameter.fs_control_arn.value,
-    FS_CRDS = data.aws_ssm_parameter.fs_crds_arn.value,
-    FS_INPUTS = data.aws_ssm_parameter.fs_inputs_arn.value,
-    FS_MESSAGES = data.aws_ssm_parameter.fs_messages_arn.value,
-    FS_OUTPUTS = data.aws_ssm_parameter.fs_outputs_arn.value
+    FS_BLACKBOARD = nonsensitive(data.aws_ssm_parameter.fs_blackboard_arn.value),
+    FS_CONTROL = nonsensitive(data.aws_ssm_parameter.fs_control_arn.value),
+    FS_CRDS = nonsensitive(data.aws_ssm_parameter.fs_crds_arn.value),
+    FS_INPUTS = nonsensitive(data.aws_ssm_parameter.fs_inputs_arn.value),
+    FS_MESSAGES = nonsensitive(data.aws_ssm_parameter.fs_messages_arn.value),
+    FS_OUTPUTS = nonsensitive(data.aws_ssm_parameter.fs_outputs_arn.value)
   })
 
   tags = {

--- a/terraform/lambda_refresh_cache_logging.tf
+++ b/terraform/lambda_refresh_cache_logging.tf
@@ -36,10 +36,8 @@ module "calcloud_lambda_refresh_cache_logs" {
   attach_network_policy = false
   attach_tracing_policy = false
   attach_async_event_policy = false
-  # existing role for the lambda
-  # will need to parametrize when ITSD takes over role creation.
-  # for now this role was created by hand in the console, it is not terraform managed
-  lambda_role = data.aws_ssm_parameter.lambda_cloudwatch_role.value
+
+  lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_cloudwatch_role.value)
 
   environment_variables = merge(local.common_env_vars, {
   })

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,10 +1,10 @@
 locals {
-       batch_subnet_ids = split(",", data.aws_ssm_parameter.batch_subnet_ids.value)
+       batch_subnet_ids = split(",", nonsensitive(data.aws_ssm_parameter.batch_subnet_ids.value))
 
-       batch_sgs = split(",", data.aws_ssm_parameter.batch_sgs.value)
+       batch_sgs = split(",", nonsensitive(data.aws_ssm_parameter.batch_sgs.value))
 
        # SSM environment value can be overridden,  also tweaked with "-" below
-       pre_environment = var.environment != null ? var.environment : data.aws_ssm_parameter.environment.value
+       pre_environment = var.environment != null ? var.environment : nonsensitive(data.aws_ssm_parameter.environment.value)
 
        # Unless the pre_environment is an empty string,  prepend an implicit "-" to the final environment value
        environment = local.pre_environment == "" ? "" : join("", ["-", local.pre_environment])
@@ -82,8 +82,8 @@ locals {
        # because we cannot reference ssm params in variables, we have to set the crds bucket here by looking up the desired bucket through a string
        # set in var.crds_bucket. We then use this map to convert that string to the correct ssm param here
        crds_bucket = {
-              "test" : data.aws_ssm_parameter.crds_test.value,
-              "ops" : data.aws_ssm_parameter.crds_ops.value,
+              "test" : nonsensitive(data.aws_ssm_parameter.crds_test.value),
+              "ops" : nonsensitive(data.aws_ssm_parameter.crds_ops.value),
        }[lookup(var.crds_bucket, local.environment, "test")]
 
        # code is cleaner to put this in locals

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output batch_ami_id {
-  value       = data.aws_ssm_parameter.batch_ami_id.value
+  value       = nonsensitive(data.aws_ssm_parameter.batch_ami_id.value)
   description = "AMI ID ssm parameter, for ITSD's latest Batch worker AMI"
 }
 
@@ -9,15 +9,15 @@ output batch_subnet_ids {
 }
 
 output batch_job_role {
-  value = data.aws_ssm_parameter.batch_job_role.value
+  value = nonsensitive(data.aws_ssm_parameter.batch_job_role.value)
 }
 
 output batch_service_role {
-  value = data.aws_ssm_parameter.batch_service_role.value
+  value = nonsensitive(data.aws_ssm_parameter.batch_service_role.value)
 }
 
 output ecs_instance_role {
-  value = data.aws_ssm_parameter.ecs_instance_role.value
+  value = nonsensitive(data.aws_ssm_parameter.ecs_instance_role.value)
 }
 
 output batch_sgs {
@@ -33,7 +33,7 @@ output region {
 }
 
 output vpc {
-  value = data.aws_ssm_parameter.vpc.value
+  value = nonsensitive(data.aws_ssm_parameter.vpc.value)
 }
 
 output predict_lambda_function_arn {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,7 +36,7 @@ variable csys_ver {
 variable pinned_tf_ver {
   description = "the intended value of the terraform installation in the environment"
   type = string
-  default = "0.14.7"
+  default = "0.15.4"
 }
 
 # valid combos


### PR DESCRIPTION
* ssm params seem to default to being sensitive. This causes terraform to complain about some outputs that are either directly sensitive, or contain a different sensitive value in their value. This can cause unpredictable behavior in some circumstances, and definitely can cause confusion about the reason that an output is being listed as sensitive.
* The cleanest way to deal with this is simply to mark every reference to an ssm_param as nonsensitive
* This is safe because:

1. There are no truly sensitive params (no keys or secrets)
2. the terraform output is not persisted anywhere, it is run in the CI node which is immediately torn down.