### PR TITLE
env-specific cache-refresh

### DIFF
--- a/lambda/refreshCacheSubmit/refresh_cache_submit.py
+++ b/lambda/refreshCacheSubmit/refresh_cache_submit.py
@@ -38,7 +38,7 @@ def lambda_handler(event, context):
             print(str(exc))
 
     # may run twice but it's better than missing an entire hour
-    if do_infrequent_refresh(dt, os.environ['CALCLOUD_ENVIRONMENT']):
+    if do_infrequent_refresh(dt, os.environ["CALCLOUD_ENVIRONMENT"]):
         for fs_name in infrequent_fileshares.keys():
             print(f"{'*'*10} refreshing cache for {fs_name} {'*'*10}")
             try:
@@ -48,9 +48,10 @@ def lambda_handler(event, context):
                 print(f"refresh cache failed for {fs_name} with exception")
                 print(str(exc))
 
+
 def do_infrequent_refresh(timestamp, env):
     # dev and test may require quick turnaround on runs and so are refreshed each time
-    override_envs = ['-dev', '-test']
+    override_envs = ["-dev", "-test"]
 
     time_test = str(timestamp.minute)[0] in ("3")
     env_test = any([s in env for s in override_envs])

--- a/lambda/refreshCacheSubmit/refresh_cache_submit.py
+++ b/lambda/refreshCacheSubmit/refresh_cache_submit.py
@@ -56,7 +56,4 @@ def do_infrequent_refresh(timestamp, env):
     time_test = str(timestamp.minute)[0] in ("3")
     env_test = any([s in env for s in override_envs])
 
-    if time_test or env_test:
-        return True
-    else:
-        return False
+    return time_test or env_test

--- a/lambda/refreshCacheSubmit/refresh_cache_submit.py
+++ b/lambda/refreshCacheSubmit/refresh_cache_submit.py
@@ -38,7 +38,7 @@ def lambda_handler(event, context):
             print(str(exc))
 
     # may run twice but it's better than missing an entire hour
-    if str(dt.minute)[0] in ("3"):
+    if do_infrequent_refresh(dt, os.environ['CALCLOUD_ENVIRONMENT']):
         for fs_name in infrequent_fileshares.keys():
             print(f"{'*'*10} refreshing cache for {fs_name} {'*'*10}")
             try:
@@ -47,3 +47,15 @@ def lambda_handler(event, context):
             except Exception as exc:
                 print(f"refresh cache failed for {fs_name} with exception")
                 print(str(exc))
+
+def do_infrequent_refresh(timestamp, env):
+    # dev and test may require quick turnaround on runs and so are refreshed each time
+    override_envs = ['-dev', '-test']
+
+    time_test = str(timestamp.minute)[0] in ("3")
+    env_test = any([s in env for s in override_envs])
+
+    if time_test or env_test:
+        return True
+    else:
+        return False

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,8 +3,8 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.16"
-CALDP_VER="0.2.10"
+CALCLOUD_VER="0.4.18"
+CALDP_VER="0.2.11"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210505_CAL_final"
 
 # this is the tag that the image will have in AWS ECR
@@ -39,7 +39,7 @@ aws_env=${aws_env_response##*:}
 aws_env=`echo $aws_env | tr -d '",'`
 
 #uncomment this to deploy to a custom env name
-aws_env="sb-bhayden"
+# aws_env="your-env-name-here"
 
 # the tf state bucket name
 aws_tfstate_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
@@ -48,8 +48,7 @@ aws_tfstate=`echo $aws_tfstate | tr -d '",'`
 echo $aws_tfstate
 
 # initial terraform setup
-# cd calcloud-${CALCLOUD_VER}/terraform
-cd ~/bhayden/calcloud/terraform
+cd calcloud-${CALCLOUD_VER}/terraform
 
 # terraform init and s3 state backend config
 awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
@@ -63,9 +62,8 @@ repo_url=${repo_url_response##*=}
 repo_url=`echo $repo_url | tr -d '"'`
 
 # build and deploy caldp docker image
-# cd ../../caldp
-cd ~/bhayden/caldp
-
+cd ../../caldp
+# cd ~/bhayden/caldp
 CALDP_DOCKER_IMAGE="${repo_url}:${CALDP_IMAGE_TAG}"
 docker build -f Dockerfile -t ${CALDP_DOCKER_IMAGE} --build-arg CAL_BASE_IMAGE=${CAL_BASE_IMAGE}  .
 # need to "log in" to ecr to push the image
@@ -73,8 +71,7 @@ awsudo $ADMIN_ARN aws ecr get-login-password --region us-east-1 | docker login -
 docker push ${CALDP_DOCKER_IMAGE}
 
 # deploy rest of terraform
-# cd ../calcloud-${CALCLOUD_VER}/terraform
-cd ~/bhayden/calcloud/terraform
+cd ../calcloud-${CALCLOUD_VER}/terraform
 # must taint the compute env to be safe about launch template handling. see comments in batch.tf
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[0]
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[1]

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,8 +3,8 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.18"
-CALDP_VER="0.2.11"
+CALCLOUD_VER="0.4.16"
+CALDP_VER="0.2.10"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210505_CAL_final"
 
 # this is the tag that the image will have in AWS ECR
@@ -39,7 +39,7 @@ aws_env=${aws_env_response##*:}
 aws_env=`echo $aws_env | tr -d '",'`
 
 #uncomment this to deploy to a custom env name
-# aws_env="your-env-name-here"
+aws_env="sb-bhayden"
 
 # the tf state bucket name
 aws_tfstate_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
@@ -48,7 +48,8 @@ aws_tfstate=`echo $aws_tfstate | tr -d '",'`
 echo $aws_tfstate
 
 # initial terraform setup
-cd calcloud-${CALCLOUD_VER}/terraform
+# cd calcloud-${CALCLOUD_VER}/terraform
+cd ~/bhayden/calcloud/terraform
 
 # terraform init and s3 state backend config
 awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
@@ -62,8 +63,9 @@ repo_url=${repo_url_response##*=}
 repo_url=`echo $repo_url | tr -d '"'`
 
 # build and deploy caldp docker image
-cd ../../caldp
-# cd ~/bhayden/caldp
+# cd ../../caldp
+cd ~/bhayden/caldp
+
 CALDP_DOCKER_IMAGE="${repo_url}:${CALDP_IMAGE_TAG}"
 docker build -f Dockerfile -t ${CALDP_DOCKER_IMAGE} --build-arg CAL_BASE_IMAGE=${CAL_BASE_IMAGE}  .
 # need to "log in" to ecr to push the image
@@ -71,7 +73,8 @@ awsudo $ADMIN_ARN aws ecr get-login-password --region us-east-1 | docker login -
 docker push ${CALDP_DOCKER_IMAGE}
 
 # deploy rest of terraform
-cd ../calcloud-${CALCLOUD_VER}/terraform
+# cd ../calcloud-${CALCLOUD_VER}/terraform
+cd ~/bhayden/calcloud/terraform
 # must taint the compute env to be safe about launch template handling. see comments in batch.tf
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[0]
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[1]


### PR DESCRIPTION
* overrides the long refresh time on inputs and control in dev and test, primarily for developers and testers who need quick turnaround on clean-all commands in order to start data processing runs on the same datasets