### PR TITLE
refactor to remove docker builds from terraform

### DIFF
--- a/modeling/Dockerfile
+++ b/modeling/Dockerfile
@@ -5,8 +5,37 @@ ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 RUN mkdir -p /etc/ssl/certs/ && mkdir -p /etc/pki/ca-trust/extracted/pem/
 COPY certs/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt && ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt && mkdir -p /etc/pki/ca-trust/extracted/openssl
-RUN DEBIAN_FRONTEND=noninteractive && NCORES=`nproc` && apt update && apt upgrade -y && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev liblzma-dev curl unzip && wget https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz && tar -xf Python-3.9.5.tgz && cd Python-3.9.5 && ./configure --enable-optimizations && make -j $NCORES && make altinstall && update-alternatives --install /usr/local/bin/python python /usr/local/bin/python3.9 10 && cd ../ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
+RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt \
+&& ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt \
+&& mkdir -p /etc/pki/ca-trust/extracted/openssl
+
+RUN DEBIAN_FRONTEND=noninteractive && NCORES=`nproc` && apt update && apt upgrade -y && apt install -y \
+build-essential \
+curl \
+libbz2-dev \
+libffi-dev \
+libgdbm-dev \
+liblzma-dev \
+libncurses5-dev \
+libnss3-dev \
+libreadline-dev \
+libsqlite3-dev \
+libssl-dev \
+unzip \
+zlib1g-dev 
+
+RUN DEBIAN_FRONTEND=noninteractive \
+&& curl -o Python-3.9.5.tgz https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz \
+&& tar -xf Python-3.9.5.tgz \
+&& cd Python-3.9.5 \
+&& ./configure --enable-optimizations \
+&& make altinstall \
+&& update-alternatives --install /usr/local/bin/python python /usr/local/bin/python3.9 10 
+
+RUN DEBIAN_FRONTEND=noninteractive \
+&& cd ../ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+&& unzip awscliv2.zip \
+&& ./aws/install
 
 WORKDIR /home/developer
 COPY requirements.txt ./

--- a/modeling/Dockerfile
+++ b/modeling/Dockerfile
@@ -5,8 +5,8 @@ ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 RUN mkdir -p /etc/ssl/certs/ && mkdir -p /etc/pki/ca-trust/extracted/pem/
 COPY certs/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt \
-&& ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt \
+RUN ln -sf /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt \
+&& ln -sf /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt \
 && mkdir -p /etc/pki/ca-trust/extracted/openssl
 
 RUN DEBIAN_FRONTEND=noninteractive && NCORES=`nproc` && apt update && apt upgrade -y && apt install -y \

--- a/modeling/Dockerfile
+++ b/modeling/Dockerfile
@@ -9,7 +9,7 @@ RUN ln -sf /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-b
 && ln -sf /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt \
 && mkdir -p /etc/pki/ca-trust/extracted/openssl
 
-RUN DEBIAN_FRONTEND=noninteractive && NCORES=`nproc` && apt update && apt upgrade -y && apt install -y \
+RUN DEBIAN_FRONTEND=noninteractive && apt update && apt upgrade -y && apt install -y \
 build-essential \
 curl \
 libbz2-dev \
@@ -36,8 +36,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
 && cd ../ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
 && unzip awscliv2.zip \
 && ./aws/install
-RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt && ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt && mkdir -p /etc/pki/ca-trust/extracted/openssl
-RUN DEBIAN_FRONTEND=noninteractive && NCORES=`nproc` && apt update && apt upgrade -y && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev liblzma-dev curl unzip && curl -o Python-3.9.5.tgz https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz && tar -xf Python-3.9.5.tgz && cd Python-3.9.5 && ./configure --enable-optimizations && make -j $NCORES && make altinstall && update-alternatives --install /usr/local/bin/python python /usr/local/bin/python3.9 10 && cd ../ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
 WORKDIR /home/developer
 COPY requirements.txt ./

--- a/modeling/Dockerfile
+++ b/modeling/Dockerfile
@@ -5,7 +5,6 @@ ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 RUN mkdir -p /etc/ssl/certs/ && mkdir -p /etc/pki/ca-trust/extracted/pem/
 COPY certs/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-<<<<<<< HEAD
 RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt \
 && ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt \
 && mkdir -p /etc/pki/ca-trust/extracted/openssl
@@ -37,10 +36,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
 && cd ../ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
 && unzip awscliv2.zip \
 && ./aws/install
-=======
 RUN ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt && ln -s /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt && mkdir -p /etc/pki/ca-trust/extracted/openssl
 RUN DEBIAN_FRONTEND=noninteractive && NCORES=`nproc` && apt update && apt upgrade -y && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev liblzma-dev curl unzip && curl -o Python-3.9.5.tgz https://www.python.org/ftp/python/3.9.5/Python-3.9.5.tgz && tar -xf Python-3.9.5.tgz && cd Python-3.9.5 && ./configure --enable-optimizations && make -j $NCORES && make altinstall && update-alternatives --install /usr/local/bin/python python /usr/local/bin/python3.9 10 && cd ../ && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
->>>>>>> 694d12babeb4671fb678d25917e4bb5e8c2e7372
 
 WORKDIR /home/developer
 COPY requirements.txt ./

--- a/modeling/ingest.py
+++ b/modeling/ingest.py
@@ -46,7 +46,7 @@ def list_jobs(messages):
     n_errors = 0
     n_ingested = 0
     n_processed = 0
-
+    n_running = 0
     for m in messages:
         msg = m.split("-")[0]
         ipst = m.split("-")[-1]
@@ -60,20 +60,22 @@ def list_jobs(messages):
             ipst = ipst.split(".")[0]
             succeeded.append(ipst)
             n_processed += 1
-        elif msg == "processing":
-            processing.append(ipst)
         else:
-            continue
-
+            processing.append(ipst)
+            n_running += 1
+    msg_count = n_errors + n_ingested + n_processed + n_running
+    print(f"Found {msg_count} completed job messages.")
     print(f"Found {n_errors} error messages.")
     print(f"Found {n_ingested} ingested jobs.")
     print(f"Found {n_processed} processed jobs.")
-    print(f"Jobs still running: {len(processing)}")
+    print(f"Jobs still running: {n_running}")
     print(f"Total # successful jobs: {len(succeeded)}")
-
-    job_dict = {"succeeded": succeeded, "processing": processing, "errors": errors}
-
-    return job_dict
+    if len(succeeded) < 1:
+        print("No data found for ingest - exiting program.")
+        sys.exit()
+    else:
+        job_dict = {"succeeded": succeeded, "processing": processing, "errors": errors}
+        return job_dict
 
 
 def scrape_jobs(bucket_proc, bucket_mod, prefix):

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -12,8 +12,10 @@ CALDP_IMAGE_TAG="latest"
 
 # these variables are overrides for developers that allow the deploy script to build from local calcloud/caldp source
 # i.e. CALCLOUD_BUILD_DIR="$HOME/deployer/calcloud"
-CALCLOUD_BUILD_DIR=""
-CALDP_BUILD_DIR=""
+# these can be set as environment variables before running to avoid changing the script directly
+# (and avoid accidentally committing a custom path to the repo...)
+CALCLOUD_BUILD_DIR=${CALCLOUD_BUILD_DIR:-""} 
+CALDP_BUILD_DIR=${CALDP_BUILD_DIR:-""}
 
 #uncomment this to deploy to a custom env name
 # aws_env="your-env-name-here"
@@ -29,7 +31,7 @@ TMP_INSTALL_DIR="/tmp/calcloud_install"
 
 # setting up the calcloud source dir if it needs downloaded
 # equivalent to "if len($var) == 0"
-if [ -z "$CALCLOUD_BUILD_DIR" ]
+if [ -z "${CALCLOUD_BUILD_DIR}" ]
 then
     mkdir -p $TMP_INSTALL_DIR
     CALCLOUD_BUILD_DIR="${TMP_INSTALL_DIR}/calcloud-$CALCLOUD_VER"
@@ -42,7 +44,7 @@ fi
 
 # setting up the caldp source dir if it needs downloaded
 # equivalent to "if len($var) == 0"
-if [ -z "$CALDP_BUILD_DIR"]
+if [ -z "${CALDP_BUILD_DIR}"]
 then
     mkdir -p $TMP_INSTALL_DIR
     CALDP_BUILD_DIR="${TMP_INSTALL_DIR}/caldp"
@@ -89,7 +91,7 @@ awsudo $ADMIN_ARN aws ecr get-login-password --region us-east-1 | docker login -
 
 # naming is confusing here but "modeling" directory plus "training" image is correct
 cd ${CALCLOUD_BUILD_DIR}/modeling
-set -o pipefail && docker build -f Dockerfile -t ${TRAINING_DOCKER_IMAGE} .
+set -o pipefail && docker build -f Dockerfile -t "${TRAINING_DOCKER_IMAGE}" .
 training_docker_build_status=$?
 if [[ $training_docker_build_status -ne 0 ]]; then
     echo "training job docker build failed; exiting"
@@ -98,7 +100,7 @@ fi
 
 # jobPredict lambda env
 cd ${CALCLOUD_BUILD_DIR}/lambda/JobPredict
-set -o pipefail && docker build -f Dockerfile -t ${MODEL_DOCKER_IMAGE} .
+set -o pipefail && docker build -f Dockerfile -t "${MODEL_DOCKER_IMAGE}" .
 model_docker_build_status=$?
 if [[ $model_docker_build_status -ne 0 ]]; then
     echo "predict lambda env docker build failed; exiting"
@@ -107,7 +109,7 @@ fi
 
 # caldp image
 cd ${CALDP_BUILD_DIR}
-set -o pipefail && docker build -f Dockerfile -t ${CALDP_DOCKER_IMAGE} --build-arg CAL_BASE_IMAGE=${CAL_BASE_IMAGE}  .
+set -o pipefail && docker build -f Dockerfile -t "${CALDP_DOCKER_IMAGE}" --build-arg CAL_BASE_IMAGE="${CAL_BASE_IMAGE}"  .
 caldp_docker_build_status=$?
 if [[ $caldp_docker_build_status -ne 0 ]]; then
     echo "caldp docker build failed; exiting"

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -12,7 +12,7 @@ CALDP_IMAGE_TAG="latest"
 
 # these variables are overrides for developers that allow the deploy script to build from local calcloud/caldp source
 # i.e. CALCLOUD_BUILD_DIR="$HOME/deployer/calcloud"
-CALCLOUD_BUILD_DIR="$HOME/bhayden/calcloud"
+CALCLOUD_BUILD_DIR=""
 CALDP_BUILD_DIR=""
 
 #uncomment this to deploy to a custom env name

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,12 +3,20 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.19"
+CALCLOUD_VER="0.4.20"
 CALDP_VER="0.2.11"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210505_CAL_final"
 
 # this is the tag that the image will have in AWS ECR
 CALDP_IMAGE_TAG="latest"
+
+# these variables are overrides for developers that allow the deploy script to build from local calcloud/caldp source
+# i.e. CALCLOUD_BUILD_DIR="$HOME/deployer/calcloud"
+CALCLOUD_BUILD_DIR="$HOME/bhayden/calcloud"
+CALDP_BUILD_DIR=""
+
+#uncomment this to deploy to a custom env name
+# aws_env="your-env-name-here"
 
 # turn CAL_BASE_IMAGE into CSYS_VER by splitting at the :, splitting again by underscore and keeping the
 # first two fields, and then converting to lowercase
@@ -18,28 +26,38 @@ CSYS_VER=`echo $CSYS_VER | awk '{print tolower($0)}'`
 
 # variables that will be changed less-frequently
 TMP_INSTALL_DIR="/tmp/calcloud_install"
-
 mkdir $TMP_INSTALL_DIR
 cd $TMP_INSTALL_DIR
 
-# calcloud source download/unpack
-wget "https://github.com/spacetelescope/calcloud/archive/v$CALCLOUD_VER.tar.gz"
-tar -xvzf "v$CALCLOUD_VER.tar.gz"
-rm "v$CALCLOUD_VER.tar.gz"
+# setting up the calcloud source dir if it needs downloaded
+# equivalent to "if len($var) == 0"
+if [ -z "$CALCLOUD_BUILD_DIR" ]
+then
+    CALCLOUD_BUILD_DIR="${TMP_INSTALL_DIR}/v$CALCLOUD_VER"
+    # calcloud source download/unpack
+    cd $TMP_INSTALL_DIR
+    wget "https://github.com/spacetelescope/calcloud/archive/v$CALCLOUD_VER.tar.gz"
+    tar -xvzf "v$CALCLOUD_VER.tar.gz"
+    rm "v$CALCLOUD_VER.tar.gz"  
+fi
 
-# caldp source download/unpack
-# github's tarballs don't work with pip install, so we have to clone and checkout the tag
-git clone https://github.com/spacetelescope/caldp.git
-cd caldp && git fetch --all --tags && git checkout tags/v${CALDP_VER} && cd ..
+# setting up the caldp source dir if it needs downloaded
+# equivalent to "if len($var) == 0"
+if [ -z "$CALDP_BUILD_DIR"]
+then
+    CALDP_BUILD_DIR="${TMP_INSTALL_DIR}/caldp"
+    cd $CALDP_BUILD_DIR
+    # caldp source download/unpack
+    # github's tarballs don't work with pip install, so we have to clone and checkout the tag
+    git clone https://github.com/spacetelescope/caldp.git
+    cd caldp && git fetch --all --tags && git checkout tags/v${CALDP_VER} && cd ..
+fi
 
 # get a couple of things from AWS ssm
 # the env, i.e. sb,dev,test,prod
 aws_env_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "environment" | grep "Value"`
 aws_env=${aws_env_response##*:}
 aws_env=`echo $aws_env | tr -d '",'`
-
-#uncomment this to deploy to a custom env name
-# aws_env="your-env-name-here"
 
 # the tf state bucket name
 aws_tfstate_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
@@ -48,7 +66,7 @@ aws_tfstate=`echo $aws_tfstate | tr -d '",'`
 echo $aws_tfstate
 
 # initial terraform setup
-cd calcloud-${CALCLOUD_VER}/terraform
+cd ${CALCLOUD_BUILD_DIR}/terraform
 
 # terraform init and s3 state backend config
 awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
@@ -61,25 +79,36 @@ repo_url=${repo_url_response##*=}
 # removes double quotes from variable
 repo_url=`echo $repo_url | tr -d '"'`
 
-# build and deploy caldp docker image
-cd ../../caldp
-# cd ~/bhayden/caldp
+##### DOCKER IMAGE BUILDING #########
 CALDP_DOCKER_IMAGE="${repo_url}:${CALDP_IMAGE_TAG}"
-docker build -f Dockerfile -t ${CALDP_DOCKER_IMAGE} --build-arg CAL_BASE_IMAGE=${CAL_BASE_IMAGE}  .
-# need to "log in" to ecr to push the image
+MODEL_DOCKER_IMAGE="${repo_url}:model"
+TRAINING_DOCKER_IMAGE="${repo_url}:training"
+
+# need to "log in" to ecr to push or pull the images
 awsudo $ADMIN_ARN aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo_url
+
+# naming is confusing here but "modeling" directory plus "training" image is correct
+cd ${CALCLOUD_BUILD_DIR}/modeling
+docker build -f Dockerfile -t ${TRAINING_DOCKER_IMAGE} .
+docker push ${TRAINING_DOCKER_IMAGE}
+# jobPredict lambda env
+cd ${CALCLOUD_BUILD_DIR}/lambda/JobPredict
+docker build -f Dockerfile -t ${MODEL_DOCKER_IMAGE} .
+docker push ${MODEL_DOCKER_IMAGE}
+# caldp image
+cd ${CALDP_BUILD_DIR}
+docker build -f Dockerfile -t ${CALDP_DOCKER_IMAGE} --build-arg CAL_BASE_IMAGE=${CAL_BASE_IMAGE}  .
 docker push ${CALDP_DOCKER_IMAGE}
 
-# deploy rest of terraform
-cd ../calcloud-${CALCLOUD_VER}/terraform
+#### PRIMARY TERRAFORM BUILD #####
+cd ${CALCLOUD_BUILD_DIR}/terraform
+
 # must taint the compute env to be safe about launch template handling. see comments in batch.tf
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[0]
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[1]
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[2]
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[3]
-
-awsudo $ADMIN_ARN terraform taint docker_registry_image.calcloud_predict_model
-awsudo $ADMIN_ARN terraform taint module.lambda_function_container_image.aws_lambda_function.this[0]
+awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.model_compute_env[0]
 
 # manual confirmation required
 awsudo $ADMIN_ARN terraform apply -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CSYS_VER}" -var "environment=${aws_env}"

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -26,13 +26,12 @@ CSYS_VER=`echo $CSYS_VER | awk '{print tolower($0)}'`
 
 # variables that will be changed less-frequently
 TMP_INSTALL_DIR="/tmp/calcloud_install"
-mkdir $TMP_INSTALL_DIR
-cd $TMP_INSTALL_DIR
 
 # setting up the calcloud source dir if it needs downloaded
 # equivalent to "if len($var) == 0"
 if [ -z "$CALCLOUD_BUILD_DIR" ]
 then
+    mkdir -p $TMP_INSTALL_DIR
     CALCLOUD_BUILD_DIR="${TMP_INSTALL_DIR}/calcloud-$CALCLOUD_VER"
     # calcloud source download/unpack
     cd $TMP_INSTALL_DIR
@@ -45,6 +44,7 @@ fi
 # equivalent to "if len($var) == 0"
 if [ -z "$CALDP_BUILD_DIR"]
 then
+    mkdir -p $TMP_INSTALL_DIR
     CALDP_BUILD_DIR="${TMP_INSTALL_DIR}/caldp"
     cd $TMP_INSTALL_DIR
     # caldp source download/unpack

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -96,9 +96,6 @@ if [[ $training_docker_build_status -ne 0 ]]; then
     exit 1
 fi
 
-echo $training_docker_build_status
-exit 1
-
 # jobPredict lambda env
 cd ${CALCLOUD_BUILD_DIR}/lambda/JobPredict
 set -o pipefail && docker build -f Dockerfile -t ${MODEL_DOCKER_IMAGE} .

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -48,10 +48,12 @@ module "calcloud_lambda_blackboard" {
 }
 
 # for cron-like schedule of blackboard lambda
+# note: in the future don't hardcode frequencies into the resource name...
+# it can be a pain to deal with renaming resources in the tf state
 resource "aws_cloudwatch_event_rule" "every_five_minutes" {
-  name                = "every-five-minutes${local.environment}"
-  description         = "Fires every five minutes"
-  schedule_expression = "rate(5 minutes)"
+  name                = "every-seven-minutes${local.environment}"
+  description         = "Fires every seven minutes"
+  schedule_expression = "rate(7 minutes)"
 }
 
 resource "aws_cloudwatch_event_target" "every_five_minutes" {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,3 +1,7 @@
+data "aws_caller_identity" "this" {}
+data "aws_region" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
 locals {
        batch_subnet_ids = split(",", nonsensitive(data.aws_ssm_parameter.batch_subnet_ids.value))
 

--- a/terraform/model_training.tf
+++ b/terraform/model_training.tf
@@ -1,13 +1,3 @@
-resource "docker_registry_image" "calcloud_model_training" {
-  name = local.ecr_model_training_image
-
-  build {
-    context = "../modeling"
-    no_cache=true
-    remove=true
-  }
-}
-
 resource "aws_batch_job_queue" "model_queue" {
   name = "calcloud-model-training-queue${local.environment}"
   count = 1


### PR DESCRIPTION
* removes any docker builds from terraform and puts them in the deploy script; greatly speeds up the actual terraform apply and is generally more convenient for troubleshooting docker builds
* adds variables to deploy.sh so that local source dirs can be used for build (developer convenience)
* modifies blackboard lambda to fire every 7 minutes instead of 5 (hopefully dealing with snapshot file corruption)
* refactors model training Dockerfile for readability (confirmed the image is the same size)
* removed a step from the python build-from-source in the Dockerfile that took 5 minutes to run python tests
* bugfix for ingest.py when no data is scraped
