### PR TITLE
adding workflows over from caldp

### DIFF
--- a/.github/scripts/check-merge-main2develop.sh
+++ b/.github/scripts/check-merge-main2develop.sh
@@ -1,0 +1,7 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git fetch
+git checkout develop
+git merge origin/main --verbose

--- a/.github/scripts/merge-main-to-develop.sh
+++ b/.github/scripts/merge-main-to-develop.sh
@@ -1,0 +1,8 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git fetch
+git checkout develop
+git merge -m "github action merged main into develop" main --verbose
+git push

--- a/.github/scripts/tag-latest.sh
+++ b/.github/scripts/tag-latest.sh
@@ -1,0 +1,9 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git checkout develop
+rev=`git rev-parse --short develop`
+git tag -f "latest" -m "latest tag updated to rev ${rev} on develop"
+git push origin :latest
+git push origin latest

--- a/.github/scripts/tag-stable.sh
+++ b/.github/scripts/tag-stable.sh
@@ -1,0 +1,9 @@
+git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --local user.name "github-actions[bot]"
+
+set -e
+git checkout main
+rev=`git rev-parse --short main`
+git tag -f "stable" -m "stable tag updated to rev ${rev} on main"
+git push origin :stable
+git push origin stable

--- a/.github/workflows/PR-check-merge.yml
+++ b/.github/workflows/PR-check-merge.yml
@@ -1,0 +1,15 @@
+name: check-merge-main2develop
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-merge-main2develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: .github/scripts/check-merge-main2develop.sh
+      

--- a/.github/workflows/merge-main-to-develop.yml
+++ b/.github/workflows/merge-main-to-develop.yml
@@ -1,0 +1,23 @@
+name: merge-main-to-develop
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-main-to-develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: .github/scripts/merge-main-to-develop.sh
+  tag-latest:
+    runs-on: ubuntu-latest
+    needs: merge-main-to-develop
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: .github/scripts/tag-latest.sh
+      

--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -1,0 +1,12 @@
+name: tag-latest
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  update-latest-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/tag-latest.sh

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -1,0 +1,12 @@
+name: tag-stable
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-stable-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: .github/scripts/tag-stable.sh


### PR DESCRIPTION
* adds a GA to tag stable on any push to main
* adds GA to merge main back into develop on any push to main
* adds GA to tag latest on any push to dev
     * note: this doesn't work if the push was done in another GA, hence the merge GA has an extra step to run this script as well
The intended workflow for developers here is that any push to main came either from a hotfix, or a release candidate branch. Any changes there need merged back to develop and this should remove the chance of that getting overlooked during a release. I do have some concerns about that merge failing, and how exactly to handle that.
* adds workflow to check for merge conflicts with develop, when a PR is opened against main
    * this is intended for informational purposes only, because after the PR is merged, another workflow will attempt to auto-merge main back into develop. If this check fails, then that will fail too. At that point developer intervention is required to fix the merge conflicts from main back to develop.
    * note that you do not need to fix the conflicts before merging to main. informational purposes only

This is all in the context of me needing to write procedures for other people to be able to create releases. So there will be instructions somewhere on exactly what the procedure is. This auto-merge of main back to dev should help to reduce some steps in that procedure.

As of now, this does not work with branch protection rules that explicitly require PRs, because we're not using any secrets in the repo that would allow the github action user to assume the appropriate privilege level.