### PR TITLE
Hotfix/v0.4.28

### DIFF
--- a/lambda/blackboard/scrape_batch.py
+++ b/lambda/blackboard/scrape_batch.py
@@ -77,7 +77,7 @@ def lambda_handler(event, context):
                         else:
                             exitReason = container.get("reason", j.get("statusReason", "None"))[:255]
 
-                        exitReason = exitReason.replace("/n", "")
+                        exitReason = exitReason.replace("\n", "")
                         dataset = j["jobName"].split("-")[-1]
 
                         # getting the LogStream requires calling describe_jobs which is very slow.

--- a/lambda/blackboard/scrape_batch.py
+++ b/lambda/blackboard/scrape_batch.py
@@ -77,6 +77,7 @@ def lambda_handler(event, context):
                         else:
                             exitReason = container.get("reason", j.get("statusReason", "None"))[:255]
 
+                        exitReason = exitReason.replace("/n", "")
                         dataset = j["jobName"].split("-")[-1]
 
                         # getting the LogStream requires calling describe_jobs which is very slow.

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,7 +3,7 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="0.4.27"
+CALCLOUD_VER="0.4.28"
 CALDP_VER="0.2.13"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20210721_CAL_final"
 


### PR DESCRIPTION
- the AWS API call to Batch for "container" "reason" can apparently include newline characters. We were dumping this string straight to the blackboard snapshot file, and the newline was breaking the on-premise poller. This hotfix replaces newline characters in the "exitReason" string with an empty string.