### PR TITLE
fix/model-ingest-lambda-config

### DIFF
--- a/calcloud/model_ingest.py
+++ b/calcloud/model_ingest.py
@@ -81,7 +81,7 @@ class Features(Scraper):
             body = None
             print(e)
         if body is None:
-            print("Unable to download inputs")
+            print(f"Unable to download inputs: {self.ipst}")
             input_data = None
             sys.exit(3)
         else:

--- a/scripts/dynamo_import.py
+++ b/scripts/dynamo_import.py
@@ -1,0 +1,88 @@
+import json
+import boto3
+import os
+import argparse
+import csv
+from decimal import Decimal
+
+s3 = boto3.resource('s3')
+dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
+
+def format_row_item(row):
+    row['timestamp'] = int(row['timestamp'])
+    row['x_files'] = float(row['x_files'])
+    row['x_size'] = float(row['x_size'])
+    row['drizcorr'] = int(row['drizcorr'])
+    row['pctecorr'] = int(row['pctecorr'])
+    row['crsplit'] = int(row['crsplit'])
+    row['subarray'] = int(row['subarray'])
+    row['detector'] = int(row['detector'])
+    row['dtype'] = int(row['dtype'])
+    row['instr'] = int(row['instr'])
+    row['wallclock'] = float(row['wallclock'])
+    row['memory'] = float(row['memory'])
+    row['mem_bin'] = float(row['mem_bin'])
+    row['n_files'] = float(row['n_files'])
+    row['total_mb'] = float(row['total_mb'])
+    row['bin_pred'] = float(row['bin_pred'])
+    row['mem_pred'] = float(row['mem_pred'])
+    row['wall_pred'] = float(row['wall_pred'])
+    return json.loads(
+        json.dumps(row, allow_nan=True),
+        parse_int=Decimal,
+        parse_float=Decimal)
+
+
+def write_to_dynamo(rows, table_name):
+    try:
+        table = dynamodb.Table(table_name)
+    except:
+        print("Error loading DynamoDB table. Check if table was created correctly and environment variable.")
+    try:
+        print("Writing batch to DDB...")
+        with table.batch_writer() as batch:
+            for i in range(len(rows)):
+                batch.put_item(
+                    Item=rows[i]
+                )
+    except:
+        print("Error executing batch_writer")
+
+
+def main(key, table_name):
+    input_file = csv.DictReader(open(key))
+    batch_size = 100
+    batch = []
+
+    for row in input_file:
+        item = format_row_item(row)
+
+        if len(batch) >= batch_size:
+            write_to_dynamo(batch, table_name)
+            batch.clear()
+            print("Batch uploaded.")
+
+        batch.append(item)
+    if batch:
+        write_to_dynamo(batch, table_name)
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Uploaded to DynamoDB Table')
+    }
+
+
+if __name__=='__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--table", help="ddb table", type=str)
+    parser.add_argument("-k", "--key", help="local csv filepath", type=str)
+    args = parser.parse_args()
+    if args.table:
+        table_name = args.table
+    else:
+        table_name = 'calcloud-model-sb'
+    if args.key:
+        key = args.key
+    else:
+        key = "latest.csv"
+    main(key, table_name)
+    

--- a/scripts/dynamo_scrape.py
+++ b/scripts/dynamo_scrape.py
@@ -1,0 +1,71 @@
+import argparse
+import boto3
+from botocore.config import Config
+import csv
+
+# mitigation of potential API rate restrictions (esp for Batch API)
+retry_config = Config(retries={"max_attempts": 5})
+client = boto3.client("s3", config=retry_config)
+dynamodb = boto3.resource("dynamodb", config=retry_config, region_name="us-east-1")
+
+def get_keys(items):
+    keys = set([])
+    for item in items:
+        keys = keys.union(set(item.keys()))
+    return keys
+
+
+def ddb_download(table_name):
+    """retrieves data from dynamodb
+    Args:
+    table_name: dynamodb table name
+    p_key: (default is 'ipst') primary key in dynamodb table
+    attr: (optional) retrieve a subset using an attribute dictionary
+    If attr is none, returns all items in database.
+    """
+    table = dynamodb.Table(table_name)
+    key_set = ["ipst"]  # primary key
+    raw_data = table.scan()
+    if raw_data is None:
+        return None
+    items = raw_data["Items"]
+    fieldnames = set([]).union(get_keys(items))
+
+    while raw_data.get("LastEvaluatedKey"):
+        raw_data = table.scan(ExclusiveStartKey=raw_data["LastEvaluatedKey"])
+        items.extend(raw_data["Items"])
+        fieldnames - fieldnames.union(get_keys(items))
+
+    print("\nTotal downloaded records: {}".format(len(items)))
+    for f in fieldnames:
+        if f not in key_set:
+            key_set.append(f)
+    ddb_data = {"items": items, "keys": key_set}
+    return ddb_data
+
+
+def write_to_csv(ddb_data, filename=None):
+    if filename is None:
+        filename = "batch.csv"
+    with open(filename, "w") as csvfile:
+        writer = csv.DictWriter(csvfile, delimiter=",", fieldnames=ddb_data["keys"], quotechar='"')
+        writer.writeheader()
+        writer.writerows(ddb_data["items"])
+    print(f"DDB data saved to: {filename}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--table", help="ddb table", type=str)
+    parser.add_argument("-k", "--key", help="output csv filename", type=str)
+    args = parser.parse_args()
+    if args.table:
+        table_name = args.table
+    else:
+        table_name = 'calcloud-model-ops'
+    if args.key:
+        key = args.key
+    else:
+        key = "latest.csv"
+    ddb_data = ddb_download(table_name)
+    write_to_csv(ddb_data, key)

--- a/terraform/lambda_model_ingest.tf
+++ b/terraform/lambda_model_ingest.tf
@@ -25,7 +25,7 @@ module "lambda_model_ingest" {
   runtime       = "python3.8"
   publish       = false
   timeout       = 180
-  memory_size   = 512
+  memory_size   = 256
   cloudwatch_logs_retention_in_days = local.lambda_log_retention_in_days
 
   source_path = [

--- a/terraform/lambda_model_ingest.tf
+++ b/terraform/lambda_model_ingest.tf
@@ -1,6 +1,6 @@
 resource "aws_dynamodb_table" "calcloud_model_db" {
   name           = "calcloud-model${local.environment}"
-  billing_mode   = "PAY_PER_REQUEST" #"PROVISIONED"
+  billing_mode   = "PAY_PER_REQUEST"
   hash_key       = "ipst"
 
   attribute {
@@ -25,6 +25,7 @@ module "lambda_model_ingest" {
   runtime       = "python3.8"
   publish       = false
   timeout       = 180
+  memory_size   = 512
   cloudwatch_logs_retention_in_days = local.lambda_log_retention_in_days
 
   source_path = [


### PR DESCRIPTION
Increased memory size to 256mb for model-ingest lambda (usage hits 125-128mb on avg)
Print ipst name to log in case of errors during s3 input scraping (for easier troubleshooting)
Added scripts for manually moving s3 backup csv files to and from DDB envs