### PR TITLE
bugfix/model-training-inputs

### DIFF
--- a/modeling/prep.py
+++ b/modeling/prep.py
@@ -162,7 +162,7 @@ def make_tensors(X_train, y_train, X_test, y_test):
 
 def split_Xy(df, target_col):
     targets = df[target_col]
-    input_cols = ['x_files', 'x_size', 'drizcorr', 'pctecorr', 'crsplit', 'subarray', 'detector', 'dtype', 'instr']
+    input_cols = ["x_files", "x_size", "drizcorr", "pctecorr", "crsplit", "subarray", "detector", "dtype", "instr"]
     features = df[input_cols]
     X = features.values
     y = targets.values


### PR DESCRIPTION
Explicitly sets order of feature columns after scraping data from DynamoDB (DDB changes the ordering after ingest which likely caused discrepancies between training and prediction).