### PR TITLE
Override and metadata parameter interchangeability

### DIFF
--- a/calcloud/exit_codes.py
+++ b/calcloud/exit_codes.py
@@ -9,7 +9,8 @@ Any errors not explicitly handled by CALDP are intended to be mapped to
 generic values of 0 or 1 to prevent conflicts with these codes.
 """
 
-_MEMORY_ERROR_NAMES = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR"]
+
+_MEMORY_ERROR_NAMES = ["SUBPROCESS_MEMORY_ERROR", "CALDP_MEMORY_ERROR", "CONTAINER_MEMORY_ERROR", "OS_MEMORY_ERROR"]
 
 
 _EXIT_CODES = dict(
@@ -27,6 +28,7 @@ _EXIT_CODES = dict(
     SUBPROCESS_MEMORY_ERROR=31,  # See caldp-process for this
     CALDP_MEMORY_ERROR=32,
     CONTAINER_MEMORY_ERROR=33,
+    OS_MEMORY_ERROR=34,
 )
 
 
@@ -47,6 +49,7 @@ _NAME_EXPLANATIONS = dict(
     CALDP_MEMORY_ERROR="CALDP generated a Python MemoryError during processing or preview creation.",
     # This is never directly returned.  It's intended to be used to trigger a container memory limit
     CONTAINER_MEMORY_ERROR="The Batch/ECS container runtime killed the job due to memory limits.",
+    OS_MEMORY_ERROR="Python raised OSError(Cannot allocate memory...),  possibly fork failure.",
 )
 
 _CODE_TO_NAME = dict()
@@ -57,6 +60,8 @@ for (name, code) in _EXIT_CODES.items():
     _CODE_TO_NAME[code] = name
     _CODE_TO_NAME[str(code)] = name
     assert name in _NAME_EXPLANATIONS
+
+# -----------------------------------------------------------------------------------------------
 
 
 def explain(exit_code):
@@ -113,6 +118,9 @@ def is_memory_error(exit_code):
     True
     """
     return (exit_code in [globals()[name] for name in _MEMORY_ERROR_NAMES]) or (exit_code in _MEMORY_ERROR_NAMES)
+
+
+# -----------------------------------------------------------------------------------------------
 
 
 def test():  # pragma: no cover

--- a/calcloud/io.py
+++ b/calcloud/io.py
@@ -11,6 +11,7 @@ import yaml
 
 from calcloud import s3
 from calcloud import hst
+from calcloud import batch
 from calcloud import log
 
 # -------------------------------------------------------------
@@ -677,6 +678,67 @@ class MetadataIo(JsonIo):
         assert hst.IPPPSSOOT_RE.match(ipppssoot) or ipppssoot in ["all", ""], f"Bad ipppssoot {ipppssoot}"
         prefix = f"{ipppssoot}/job.json" if ipppssoot not in ["all", ""] else ""
         return super().path(prefix)
+
+
+# Control values can be sent as part of message override payloads or can be recorded in comm.xdata.
+# XXXX NOTE: value checks are not currently active,  only field name and type.
+CONTROL_KEYWORDS = {
+    "cancel_type": ((str,), lambda x: x in ("job_id", "ipppssoot")),
+    "job_id": ((str,), batch.JOB_ID_RE.match),
+    "memory_bin": ((int, type(None)), lambda x: x in (0, 1, 2, 3, None)),
+    "terminated": ((bool,), lambda x: True),
+    "timeout_scale": ((int, float), lambda x: x > 0),
+    "ipppssoot": ((str,), hst.IPPPSSOOT_RE.match),
+    "bucket": ((str,), lambda x: True),
+    "job_name": ((str,), lambda x: True),
+    "exit_code": ((int, str), lambda x: True),
+    "exit_reason": ((str,), lambda x: True),
+    "exit_status": ((str,), lambda x: True),
+    "status_reason": (
+        (
+            int,
+            str,
+        ),
+        lambda x: True,
+    ),
+    "container_reason": (
+        (
+            int,
+            str,
+        ),
+        lambda x: True,
+    ),
+    "memory_retries": ((int,), lambda x: x >= 0),
+    "retries": ((int,), lambda x: x >= 0),
+}
+
+
+def validate_control(metadata):
+    """Check the `metadata` dictionary for valid keywords and value types."""
+    log.info("Validating control metadata", metadata)
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, dict):
+        raise ValueError("Job metadata isn't a dict.")
+    for key, value in metadata.items():
+        defined = CONTROL_KEYWORDS.get(key)
+        if defined:
+            valid_types = defined[0]
+            if not isinstance(value, valid_types):
+                raise ValueError(f"Control value for {key} should be one of these types: {valid_types}.")
+            # f_valid_value = defined[1]
+            # if not f_valid_value(value):
+            #    raise ValueError(f"Control value for {key} is not valid.")
+        else:
+            raise ValueError(f"Control keyword {key} is not one of {sorted(list(CONTROL_KEYWORDS))}.")
+    return metadata
+
+
+def get_default_metadata():
+    """Return the default metadata needed to run the planner if no corresponding overrides or control data
+    are defined.
+    """
+    return dict(retries=0, memory_retries=0, memory_bin=None, job_id="undefined", terminated=False, timeout_scale=1.0)
 
 
 # -------------------------------------------------------------

--- a/calcloud/plan.py
+++ b/calcloud/plan.py
@@ -67,7 +67,7 @@ def get_plan(ipppssoot, output_bucket, input_path, metadata):
                           intended to drive increasing memory for each subsequent retry
                           with the maximum retry value set in Terraform.
        memory_bin      absolute memory bin number or None
-       timeout_scale      factor to multiply kill time by
+       timeout_scale   factor to multiply kill time by
 
     Returns    Plan   (named tuple)
     """
@@ -146,7 +146,8 @@ def _get_environment(job_resources, memory_retries, memory_bin):
     job_queues = os.environ["JOBQUEUES"].split(",")
     job_resources = JobResources(*job_resources)
 
-    final_bin = memory_bin if memory_bin is not None else job_resources.initial_modeled_bin + memory_retries
+    final_bin = memory_bin if memory_bin is not None else job_resources.initial_modeled_bin
+    final_bin += memory_retries
     if final_bin < len(job_defs):
         log.info(
             "Selecting resources for",

--- a/lambda/JobDelete/delete_handler.py
+++ b/lambda/JobDelete/delete_handler.py
@@ -44,7 +44,7 @@ def lambda_handler(event, context):
         comm.messages.delete_literal(f"cancel-{job_id}")
         with log.trap_exception("Handling messages + control for", job_id):
             ipst = batch.get_job_name(job_id)
-            print("Handlign messages and control for", ipst)
+            print("Handling messages and control for", ipst)
             comm.messages.delete(f"all-{ipst}")
             comm.messages.put(f"terminated-{ipst}", "cancel lambda " + bucket_name)
             try:
@@ -62,6 +62,7 @@ def lambda_handler(event, context):
         comm.messages.put(f"terminated-{ipst}", "cancel lambda " + bucket_name)
         metadata = comm.xdata.get(ipst)
         metadata["terminated"] = True
+        metadata["cancel_type"] = "ipppssoot"
         comm.xdata.put(ipst, metadata)
         job_id = metadata["job_id"]
         with log.trap_exception("Terminating", job_id):


### PR DESCRIPTION
Refactor submit message payload handling to make stored metadata vs. override
  parameters more interchangeable.
Add memory_bin parameter as absolute override of bin,  used instead of model or
  memory_retries increments.
Pass all metadata parameters into planner to reduce changes required as new
  planning parameters are added in the future.