### PR TITLE
Module and provider version updates tested with Terraform-1.0.11

### DIFF
--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -8,11 +8,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.42.0"
-    }
-    hashicorp-template = {
-      source = "hashicorp/template"
-      version = "~> 2.2.0"
+      version = "~> 3.65.0"
     }
     hashicorp-null = {
       source = "hashicorp/null"
@@ -32,17 +28,12 @@ terraform {
     }
     docker = {
       source = "kreuzwerker/docker"
-      version = "~> 2.11.0"
+      version = "~> 2.15.0"
     }
   }
 }
 
-data "template_file" "userdata" {
-  template = file("${path.module}/user_data.sh")
-  vars = {
-      // Any var you need to pass to the script
-  }
-}
+# See also lambda module version in each lambda .tf file
 
 resource "aws_launch_template" "hstdp" {
   # IF YOU CHANGE THE LAUNCH TEMPLATE YOU MUST "TAINT" THE COMPUTE ENVIRONMENT BEFORE DEPLOY
@@ -58,7 +49,7 @@ resource "aws_launch_template" "hstdp" {
     "Name"         = "calcloud-hst-worker${local.environment}"
     "calcloud-hst" = "calcloud-hst-worker${local.environment}"
   }
-  user_data               = base64encode(data.template_file.userdata.rendered)
+  user_data               = base64encode(templatefile("${path.module}/user_data.sh", {}))
 
   vpc_security_group_ids  = local.batch_sgs
 

--- a/terraform/lambda_batch_events.tf
+++ b/terraform/lambda_batch_events.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_batchEvents" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-job-events${local.environment}"
   description   = "listens for Batch failure events from cloudWatch event rule"
@@ -77,13 +77,13 @@ EOF
 resource "aws_cloudwatch_event_target" "batch_events" {
   rule      = aws_cloudwatch_event_rule.batch.name
   target_id = "lambda"
-  arn       = module.calcloud_lambda_batchEvents.this_lambda_function_arn
+  arn       = module.calcloud_lambda_batchEvents.lambda_function_arn
 }
 
 resource "aws_lambda_permission" "allow_lambda_exec_batch" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_batchEvents.this_lambda_function_name
+  function_name = module.calcloud_lambda_batchEvents.lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.batch.arn
 }

--- a/terraform/lambda_blackboard.tf
+++ b/terraform/lambda_blackboard.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_blackboard" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-job-blackboard${local.environment}"
   description   = "scrapes the Batch console for job metadata and posts to S3 bucket for on-premise poller"
@@ -64,13 +64,13 @@ resource "aws_cloudwatch_event_rule" "every_five_minutes" {
 resource "aws_cloudwatch_event_target" "every_five_minutes" {
   rule      = aws_cloudwatch_event_rule.every_five_minutes.name
   target_id = "lambda"
-  arn       = module.calcloud_lambda_blackboard.this_lambda_function_arn
+  arn       = module.calcloud_lambda_blackboard.lambda_function_arn
 }
 
 resource "aws_lambda_permission" "allow_lambda_exec" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_blackboard.this_lambda_function_name
+  function_name = module.calcloud_lambda_blackboard.lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.every_five_minutes.arn
 }

--- a/terraform/lambda_broadcast.tf
+++ b/terraform/lambda_broadcast.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_broadcast" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-broadcast${local.environment}"
   description   = "Broadcasts the specified message type across a list of job_ids or ippppssoots."
@@ -56,7 +56,7 @@ module "calcloud_lambda_broadcast" {
 resource "aws_lambda_permission" "allow_bucket_broadcastLambda" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_broadcast.this_lambda_function_arn
+  function_name = module.calcloud_lambda_broadcast.lambda_function_arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
   source_account = data.aws_caller_identity.this.account_id

--- a/terraform/lambda_common.tf
+++ b/terraform/lambda_common.tf
@@ -63,37 +63,37 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.calcloud.id
 
   lambda_function {
-    lambda_function_arn = module.calcloud_lambda_submit.this_lambda_function_arn
+    lambda_function_arn = module.calcloud_lambda_submit.lambda_function_arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "messages/placed-"
   }
 
   lambda_function {
-    lambda_function_arn = module.calcloud_lambda_deleteJob.this_lambda_function_arn
+    lambda_function_arn = module.calcloud_lambda_deleteJob.lambda_function_arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "messages/cancel-"
   }
 
   lambda_function {
-    lambda_function_arn = module.calcloud_lambda_rescueJob.this_lambda_function_arn
+    lambda_function_arn = module.calcloud_lambda_rescueJob.lambda_function_arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "messages/rescue-"
   }
 
   lambda_function {
-    lambda_function_arn = module.calcloud_lambda_broadcast.this_lambda_function_arn
+    lambda_function_arn = module.calcloud_lambda_broadcast.lambda_function_arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "messages/broadcast-"
   }
 
   lambda_function {
-    lambda_function_arn = module.calcloud_lambda_cleanJob.this_lambda_function_arn
+    lambda_function_arn = module.calcloud_lambda_cleanJob.lambda_function_arn
     events              = ["s3:ObjectCreated:Put"]
     filter_prefix       = "messages/clean-"
   }
 
   lambda_function {
-    lambda_function_arn = module.lambda_model_ingest.this_lambda_function_arn
+    lambda_function_arn = module.lambda_model_ingest.lambda_function_arn
     events = ["s3:ObjectCreated:Put"]
     filter_prefix = "messages/processed-"
     filter_suffix = ".trigger"

--- a/terraform/lambda_job_clean.tf
+++ b/terraform/lambda_job_clean.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_cleanJob" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-job-clean${local.environment}"
   description   = "accepts messages from s3 event and cleans either individual jobs by ipppssoot, or all active jobs"
@@ -56,7 +56,7 @@ module "calcloud_lambda_cleanJob" {
 resource "aws_lambda_permission" "allow_bucket_cleanLambda" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_cleanJob.this_lambda_function_arn
+  function_name = module.calcloud_lambda_cleanJob.lambda_function_arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
   source_account = data.aws_caller_identity.this.account_id

--- a/terraform/lambda_job_delete.tf
+++ b/terraform/lambda_job_delete.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_deleteJob" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-job-delete${local.environment}"
   description   = "accepts messages from s3 event and deletes either individual jobs by ipppssoot, or all active jobs"
@@ -56,7 +56,7 @@ module "calcloud_lambda_deleteJob" {
 resource "aws_lambda_permission" "allow_bucket_deleteLambda" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_deleteJob.this_lambda_function_arn
+  function_name = module.calcloud_lambda_deleteJob.lambda_function_arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
   source_account = data.aws_caller_identity.this.account_id

--- a/terraform/lambda_job_predict.tf
+++ b/terraform/lambda_job_predict.tf
@@ -1,6 +1,6 @@
 module "lambda_function_container_image" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
   function_name = "calcloud-job-predict${local.environment}"
   description   = "pretrained neural networks for predicting job resource requirements (memory bin and max execution time)"
 

--- a/terraform/lambda_job_rescue.tf
+++ b/terraform/lambda_job_rescue.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_rescueJob" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-job-rescue${local.environment}"
   description   = "Rescues the specified ipppssoot (must be in error state) by deleting all outputs and messages and re-placing."
@@ -45,7 +45,7 @@ module "calcloud_lambda_rescueJob" {
   lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_rescue_role.value)
 
   environment_variables = merge(local.common_env_vars, {
-      JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,
+      JOBPREDICTLAMBDA = module.lambda_function_container_image.lambda_function_arn,
       SUBMIT_TIMEOUT = 14*60,  # leave some room for polling jitter, 14 min vs  15 min above
       DDBTABLE = "${aws_dynamodb_table.calcloud_model_db.name}"
   })   
@@ -59,7 +59,7 @@ module "calcloud_lambda_rescueJob" {
 resource "aws_lambda_permission" "allow_bucket_rescueLambda" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_rescueJob.this_lambda_function_arn
+  function_name = module.calcloud_lambda_rescueJob.lambda_function_arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
   source_account = data.aws_caller_identity.this.account_id

--- a/terraform/lambda_job_submit.tf
+++ b/terraform/lambda_job_submit.tf
@@ -1,7 +1,7 @@
 module "calcloud_lambda_submit" {
   source = "terraform-aws-modules/lambda/aws"
   # https://github.com/hashicorp/terraform/issues/17211
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-job-submit${local.environment}"
   description   = "looks for placed-ipppssoot messages and submits jobs to Batch"
@@ -46,7 +46,7 @@ module "calcloud_lambda_submit" {
   lambda_role = nonsensitive(data.aws_ssm_parameter.lambda_submit_role.value)
 
   environment_variables = merge(local.common_env_vars, {
-      JOBPREDICTLAMBDA = module.lambda_function_container_image.this_lambda_function_arn,
+      JOBPREDICTLAMBDA = module.lambda_function_container_image.lambda_function_arn,
       SUBMIT_TIMEOUT = 14*60,  # leave some room for polling jitter, 14 min vs  15 min above. This is our timeout so error handling / cleanup should occur
       DDBTABLE = "${aws_dynamodb_table.calcloud_model_db.name}"
   })                           
@@ -60,7 +60,7 @@ module "calcloud_lambda_submit" {
 resource "aws_lambda_permission" "allow_bucket" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_submit.this_lambda_function_arn
+  function_name = module.calcloud_lambda_submit.lambda_function_arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
   source_account = data.aws_caller_identity.this.account_id

--- a/terraform/lambda_model_ingest.tf
+++ b/terraform/lambda_model_ingest.tf
@@ -16,13 +16,13 @@ resource "aws_dynamodb_table" "calcloud_model_db" {
 
 module "lambda_model_ingest" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-model-ingest${local.environment}"
   lambda_role = nonsensitive(data.aws_ssm_parameter.model_ingest_role.value)
   description   = "looks for processed-ipppssoot.trigger messages, scrapes and uploads completed job data to DynamoDB"
   handler       = "lambda_scrape.lambda_handler"
-  runtime       = "python3.8"
+  runtime       = "python3.7"
   publish       = false
   timeout       = 180
   memory_size   = 256
@@ -65,7 +65,7 @@ module "lambda_model_ingest" {
 resource "aws_lambda_permission" "allow_bucket_ingestLambda" {
   statement_id  = "AllowExecutionFromS3Bucket"
   action        = "lambda:InvokeFunction"
-  function_name = module.lambda_model_ingest.this_lambda_function_arn
+  function_name = module.lambda_model_ingest.lambda_function_arn
   principal     = "s3.amazonaws.com"
   source_arn    = aws_s3_bucket.calcloud.arn
   source_account = data.aws_caller_identity.this.account_id

--- a/terraform/lambda_refresh_cache.tf
+++ b/terraform/lambda_refresh_cache.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_refresh_cache_submit" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-fileshare-refresh_cache_submit${local.environment}"
   description   = "submits refresh cache operations"
@@ -67,13 +67,13 @@ resource "aws_cloudwatch_event_rule" "refresh_cache_schedule" {
 resource "aws_cloudwatch_event_target" "refresh_cache_submit" {
   rule      = aws_cloudwatch_event_rule.refresh_cache_schedule.name
   target_id = "lambda"
-  arn       = module.calcloud_lambda_refresh_cache_submit.this_lambda_function_arn
+  arn       = module.calcloud_lambda_refresh_cache_submit.lambda_function_arn
 }
 
 resource "aws_lambda_permission" "refresh_cache_submit" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_refresh_cache_submit.this_lambda_function_name
+  function_name = module.calcloud_lambda_refresh_cache_submit.lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.refresh_cache_schedule.arn
 }

--- a/terraform/lambda_refresh_cache_logging.tf
+++ b/terraform/lambda_refresh_cache_logging.tf
@@ -1,6 +1,6 @@
 module "calcloud_lambda_refresh_cache_logs" {
   source = "terraform-aws-modules/lambda/aws"
-  version = "~> 1.43.0"
+  version = "~> 2.26.0"
 
   function_name = "calcloud-fileshare-refresh_cache_logs${local.environment}"
   description   = "listens for refresh cache operations and logs them"
@@ -72,13 +72,13 @@ EOF
 resource "aws_cloudwatch_event_target" "refresh_cache_logs" {
   rule      = aws_cloudwatch_event_rule.refresh_cache_logs.name
   target_id = "lambda"
-  arn       = module.calcloud_lambda_refresh_cache_logs.this_lambda_function_arn
+  arn       = module.calcloud_lambda_refresh_cache_logs.lambda_function_arn
 }
 
 resource "aws_lambda_permission" "allow_lambda_exec_refresh_cache_logs" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = module.calcloud_lambda_refresh_cache_logs.this_lambda_function_name
+  function_name = module.calcloud_lambda_refresh_cache_logs.lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.refresh_cache_logs.arn
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -37,7 +37,7 @@ output vpc {
 }
 
 output predict_lambda_function_arn {
-  value = module.lambda_function_container_image.this_lambda_function_arn
+  value = module.lambda_function_container_image.lambda_function_arn
 }
 
 output s3_output_bucket {


### PR DESCRIPTION
Updates needed for Terraform-1.0.11 and/or provider and module version pacing.

Switch from template_file resource to templatefile() function.
Update aws ~3.42.0 to ~3.65.0
Update docker ~2.11.0  to ~2.15.0
Update lambda/aws ~1.43.0 to ~2.26.0,  rename parameters this_lambda_xxx to lambda_xxx dropping this_
