### PR TITLE
Hotfix/nss update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,1 @@
-- base image update to CALDP_20211129_CAL_final
+- force update of nss due to critical security vulnerability

--- a/lambda/JobPredict/Dockerfile
+++ b/lambda/JobPredict/Dockerfile
@@ -3,6 +3,7 @@ FROM amazon/aws-lambda-python:3.7
 COPY requirements.txt predict_handler.py ./
 # SSL/TLS cert setup for STScI AWS firewalling
 USER root
+# temporary. remove when nss in the base amazon image is secure again
 RUN yum update nss -y
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

--- a/lambda/JobPredict/Dockerfile
+++ b/lambda/JobPredict/Dockerfile
@@ -3,6 +3,7 @@ FROM amazon/aws-lambda-python:3.7
 COPY requirements.txt predict_handler.py ./
 # SSL/TLS cert setup for STScI AWS firewalling
 USER root
+RUN yum update nss -y
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ENV CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -3,7 +3,7 @@
 # ADMIN_ARN is set in the ci node env and should not be included in this deploy script
 
 # variables that will likely be changed frequently
-CALCLOUD_VER="v0.4.31"
+CALCLOUD_VER="v0.4.32"
 CALDP_VER="v0.2.16"
 CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20211129_CAL_final"
 


### PR DESCRIPTION
the CALDP image is being fixed in the base image, so no caldp changes are needed. In fact, the yum update in the caldp Dockerfile picks up the nss updates (for certain mirrors; not all mirrors seem to know about the nss updates yet though)