### PR TITLE
Release/v0.4.35

### DIFF
--- a/calcloud/model_ingest.py
+++ b/calcloud/model_ingest.py
@@ -272,7 +272,7 @@ def create_payload(job_data, timestamp):
         "mem_bin": int(targets["mem_bin"]),
     }
     ddb_payload = json.loads(json.dumps(data, allow_nan=True), parse_int=Decimal, parse_float=Decimal)
-    pprint(ddb_payload, indent=2, sort_dicts=False)
+    pprint(ddb_payload, indent=2)
     return ddb_payload
 
 
@@ -291,7 +291,7 @@ def ddb_ingest(ipst, bucket_name, table_name):
     ddb_payload = create_payload(job_data, start_time)
     job_resp = put_job_data(ddb_payload, table_name)
     print("Put job data succeeded:")
-    pprint(job_resp, indent=2, sort_dicts=False)
+    pprint(job_resp, indent=2)
     end_time = time.time()
     print_timestamp(end_time, "SCRAPE and INGEST", 1)
     duration = proc_time(start_time, end_time)

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,3 @@
-- pytest via moto (no need for aws creds)
-- fix ami-rotation issues caused by yum
-- updated memory model training
-- bugfix; blackboard 'createdAt' default value supplied (hotfixed previously)
-- significantly reduce frequency of blackboard lambda to avoid problems with the file in the storage gateway
-- refactor terraform for ami rotation user-data
-- terraform package version bumps
-- remove terraformed ecr repo in each account; use central ecr via ssm param instead
-- significant refactor of deployment scripts to handle central ecr and image promotion/deletion that goes with it
-- cache refresh period increased to 9 minutes from 5 (continued gateway tweaks)
+- default base docker image set to CALDP_20220406_CAL_final
+- default crds update to hst_1002.pmap
+- bugfix for model ingest lambda pprint (missing optional param "sort_dicts" after downgrade to 3.7 runtime)

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,9 +1,8 @@
 #! /bin/bash -xu
 
-export CALCLOUD_VER="v0.4.35-rc1"
-export CALDP_VER="v0.2.18-rc1"
-export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_mvmbeta_CAL_rc3"
-
+export CALCLOUD_VER="v0.4.35-rc2"
+export CALDP_VER="v0.2.18-rc2"
+export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_mvmbeta_CAL_rc4"
 
 export BASE_IMAGE_TAG=`cut -d ":" -f2- <<< ${CAL_BASE_IMAGE} `
 

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,7 +1,7 @@
 #! /bin/bash -xu
 
-export CALCLOUD_VER="v0.4.35-rc2"
-export CALDP_VER="v0.2.18-rc3"
+export CALCLOUD_VER="v0.4.35-rc3"
+export CALDP_VER="v0.2.18-rc2"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_mvmbeta_CAL_rc4"
 
 export BASE_IMAGE_TAG=`cut -d ":" -f2- <<< ${CAL_BASE_IMAGE} `

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,8 +1,9 @@
 #! /bin/bash -xu
 
-export CALCLOUD_VER="v0.4.34"
-export CALDP_VER="v0.2.17"
-export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20211129_CAL_final"
+export CALCLOUD_VER="v0.4.35-rc1"
+export CALDP_VER="v0.2.18-rc1"
+export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_mvmbeta_CAL_rc3"
+
 
 export BASE_IMAGE_TAG=`cut -d ":" -f2- <<< ${CAL_BASE_IMAGE} `
 

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,7 +1,7 @@
 #! /bin/bash -xu
 
 export CALCLOUD_VER="v0.4.35-rc2"
-export CALDP_VER="v0.2.18-rc2"
+export CALDP_VER="v0.2.18-rc3"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_mvmbeta_CAL_rc4"
 
 export BASE_IMAGE_TAG=`cut -d ":" -f2- <<< ${CAL_BASE_IMAGE} `

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,8 +1,8 @@
 #! /bin/bash -xu
 
-export CALCLOUD_VER="v0.4.35-rc3"
-export CALDP_VER="v0.2.18-rc2"
-export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_mvmbeta_CAL_rc4"
+export CALCLOUD_VER="v0.4.35"
+export CALDP_VER="v0.2.18"
+export CAL_BASE_IMAGE="stsci/hst-pipeline:CALDP_20220406_CAL_final"
 
 export BASE_IMAGE_TAG=`cut -d ":" -f2- <<< ${CAL_BASE_IMAGE} `
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,8 +105,8 @@ variable crds_context {
   default = {
     "-sb" = "hst_0866.pmap"
     "-dev" = "hst_0866.pmap"
-    "-test" = "hst_0996.pmap"
-    "-ops" = "hst_0996.pmap"
+    "-test" = "hst_1002.pmap"
+    "-ops" = "hst_1002.pmap"
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,8 +105,8 @@ variable crds_context {
   default = {
     "-sb" = "hst_0866.pmap"
     "-dev" = "hst_0866.pmap"
-    "-test" = "hst_0981.pmap"
-    "-ops" = "hst_0981.pmap"
+    "-test" = "hst_0989.pmap"
+    "-ops" = "hst_0989.pmap"
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -105,8 +105,8 @@ variable crds_context {
   default = {
     "-sb" = "hst_0866.pmap"
     "-dev" = "hst_0866.pmap"
-    "-test" = "hst_0989.pmap"
-    "-ops" = "hst_0989.pmap"
+    "-test" = "hst_0996.pmap"
+    "-ops" = "hst_0996.pmap"
   }
 }
 


### PR DESCRIPTION
- default base docker image set to CALDP_20220406_CAL_final
- default crds update to hst_1002.pmap
- bugfix for model ingest lambda pprint (missing optional param "sort_dicts" after downgrade to 3.7 runtime)
