### PR TITLE
CALCLOUD-464 Make amirotate codebuild script work again

### DIFF
--- a/ami_rotation/parse_image_json.py
+++ b/ami_rotation/parse_image_json.py
@@ -3,9 +3,24 @@ import json
 from collections import OrderedDict
 from datetime import datetime
 
-response = json.loads(str(sys.argv[1]))
+# This command parses the response to `aws ec2 describe-images`.
+# This response can be so long that it cannot be passed on the command-line.
+# When you call this program, you can either:
+# 1. pass the response on the command line, followed by the image-name-prefix
+# 2. store the response in a file called images.json, and only pass the image-name-prefix
+if len(sys.argv) == 3:
+    # Response has been passed on command-line
+    input_string = str(sys.argv[1])
+
+    image_name_filter = sys.argv[2]
+else:
+    # Response is in images.json file
+    with open("images.json", "r") as f:
+        input_string = f.read()
+    image_name_filter = sys.argv[1]
+
+response = json.loads(input_string)
 images = response["Images"]
-image_name_filter = sys.argv[2]
 
 stsciLinux2Ami = {}
 for image in images:

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -14,14 +14,9 @@ echo $aws_tfstate
 
 # get AMI id(s)
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-# Limit responses to the most recent 24 images to prevent "Argument list too long"
-query='{Images: reverse(sort_by(Images, &CreationDate))[:24]}'
-ami_json="$(
-  awsudo "$ADMIN_ARN" \
-  "aws ec2 describe-images --region us-east-1 --executable-users self --query '$query' --output json"
-)"
-ci_ami=`python3 parse_image_json.py "${ami_json}" STSCI-AMAZON-LINUX2023`
-ecs_ami=`python3 parse_image_json.py "${ami_json}" STSCI-EPH-ECS-AL2023`
+awsudo $ADMIN_ARN ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+ci_ami=`python3 parse_image_json.py STSCI-AMAZON-LINUX2023`
+ecs_ami=`python3 parse_image_json.py STSCI-EPH-ECS-AL2023`
 
 if [[ "$ci_ami" =~ ^ami-[a-z0-9]+$ ]]; then
     echo $ci_ami

--- a/terraform/deploy_ami_rotate.sh
+++ b/terraform/deploy_ami_rotate.sh
@@ -75,9 +75,9 @@ echo $aws_tfstate
 
 # get AMI id
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-ami_json=$(echo $(awsudo $ADMIN_ARN aws ec2 describe-images --region us-east-1 --executable-users self))
-ci_ami=`python3 parse_image_json.py "${ami_json}" STSCI-AMAZON-LINUX2023`
-ecs_ami=`python3 parse_image_json.py "${ami_json}" STSCI-EPH-ECS-AL2023`
+awsudo $ADMIN_ARN ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+ci_ami=`python3 parse_image_json.py STSCI-AMAZON-LINUX2023`
+ecs_ami=`python3 parse_image_json.py STSCI-EPH-ECS-AL2023`
 
 if [[ "$ci_ami" =~ ^ami-[a-z0-9]+$ ]]; then
     echo $ci_ami

--- a/terraform/deploy_ami_rotate_codebuild_script.sh
+++ b/terraform/deploy_ami_rotate_codebuild_script.sh
@@ -76,9 +76,9 @@ echo $aws_tfstate
 
 # get AMI id
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-ami_json=$(echo $(aws ec2 describe-images --region us-east-1 --executable-users self))
-ci_ami=`python3 parse_image_json.py "${ami_json}" STSCI-AMAZON-LINUX2023`
-ecs_ami=`python3 parse_image_json.py "${ami_json}" STSCI-EPH-ECS-AL2023`
+aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+ci_ami=`python3 parse_image_json.py STSCI-AMAZON-LINUX2023`
+ecs_ami=`python3 parse_image_json.py STSCI-EPH-ECS-AL2023`
 
 if [[ "$ci_ami" =~ ^ami-[a-z0-9]+$ ]]; then
     echo $ci_ami
@@ -116,7 +116,7 @@ terraform plan -no-color -var "environment=${aws_env}" -out ami_rotate.out \
     -target aws_launch_template.ami_rotation \
     -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CSYS_VER}" -var "environment=${aws_env}" -var "ci_ami=${ci_ami}" -var "ecs_ami=${ecs_ami}"
 
+terraform show ami_rotate.out > "ami_rotate.txt"
 terraform apply -no-color "ami_rotate.out"
 
 cd $HOME
-rm -rf $TMP_INSTALL_DIR


### PR DESCRIPTION
Do not pass the output of `aws ec2 describe-images` on the command line. It is too long for the OS to handle.  Instead, pass it through a file.

I noticed that the CodeBuild project calcloud-ami-rotation-ops was failing in all accounts (CodeBuild > Build > Build projetcs > calcloud-ami-roration-ops): https://us-east-1.console.aws.amazon.com/codesuite/codebuild/812556236571/projects/calcloud-ami-rotation-ops/history

I think there are two reasons this is failing.  The easier one is that in three files, we call `parse_image_json.py` with the output of `aws ec2 describe-images`.  This output is about 400K, and that is too long to pass on the command-line. 
- deploy.sh
- deploy_ami_rotate.sh - I think this is unused
- deploy_ami_rotate_codebuild_script.sh

@raswaters, you made this change to correct it in deploy.sh, but did not make the change in the other locations:
https://github.com/spacetelescope/calcloud/commit/fe1a6a7fecf9f2d856c7c3a7d0285c71e010d13c

I applied your fix to deploy_ami_rotate_codebuild_script.sh in the sandbox account, but I had problems testing because of bash quoting madness.  I changed the code to instead pass the json output through a file and verify that works.  I think this is a better solution, so I made the change in the deploy.sh script as well.