### PR TITLE
CALCLOUD-462 Increase disk size for reprocessing MVMs

### DIFF
--- a/calcloud/plan.py
+++ b/calcloud/plan.py
@@ -147,8 +147,9 @@ def _get_resources(dataset, dataset_type, output_bucket, input_path, timeout_sca
 
     disk_size = "large-volume" if dataset_type == "mvm" else "default"
 
-    return JobResources(dataset, instr, job_name, s3_output_uri, input_path, crds_config, initial_bin, kill_time,
-                        disk_size)
+    return JobResources(
+        dataset, instr, job_name, s3_output_uri, input_path, crds_config, initial_bin, kill_time, disk_size
+    )
 
 
 def _get_environment(job_resources, memory_retries, memory_bin):

--- a/calcloud/plan.py
+++ b/calcloud/plan.py
@@ -37,6 +37,7 @@ JobResources = namedtuple(
         "crds_config",
         "initial_modeled_bin",
         "max_seconds",
+        "disk_size",
     ],
 )
 
@@ -144,7 +145,10 @@ def _get_resources(dataset, dataset_type, output_bucket, input_path, timeout_sca
     # minimum Batch requirement 60 seconds
     kill_time = int(max(kill_time, 60))
 
-    return JobResources(dataset, instr, job_name, s3_output_uri, input_path, crds_config, initial_bin, kill_time)
+    disk_size = "large-volume" if dataset_type == "mvm" else "default"
+
+    return JobResources(dataset, instr, job_name, s3_output_uri, input_path, crds_config, initial_bin, kill_time,
+                        disk_size)
 
 
 def _get_environment(job_resources, memory_retries, memory_bin):
@@ -155,6 +159,13 @@ def _get_environment(job_resources, memory_retries, memory_bin):
     job_defs = os.environ["JOBDEFINITIONS"].split(",")
     job_queues = os.environ["JOBQUEUES"].split(",")
     job_resources = JobResources(*job_resources)
+
+    if job_resources.disk_size == "large-volume":
+        job_queues = [x for x in job_queues if "large-volume" in x]
+        job_defs = [x for x in job_defs if "large-volume" in x]
+    else:
+        job_queues = [x for x in job_queues if "large-volume" not in x]
+        job_defs = [x for x in job_defs if "large-volume" not in x]
 
     final_bin = memory_bin if memory_bin is not None else job_resources.initial_modeled_bin
     final_bin += memory_retries

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -35,19 +35,38 @@ terraform {
 
 # See also lambda module version in each lambda .tf file
 
+# We must use a different launch template for each volume size we use.
+locals {
+  launch_templates = {
+    default = {
+      name_suffix       = ""
+      volume_size       = 150
+      description_infix = ""
+    }
+    large-volume = {
+      name_suffix       = "-large-volume"
+      volume_size       = 3000
+      description_infix = "large-volume "
+    }
+  }
+}
+
 resource "aws_launch_template" "hstdp" {
   # IF YOU CHANGE THE LAUNCH TEMPLATE YOU MUST "TAINT" THE COMPUTE ENVIRONMENT BEFORE DEPLOY
   # IN ORDER FOR YOUR CHANGES TO BE PICKED UP BY BATCH
   # See https://docs.aws.amazon.com/batch/latest/userguide/create-compute-environment.html
   # and https://github.com/hashicorp/terraform-provider-aws/issues/15535
-  name = "calcloud-hst-worker${local.environment}"
-  description             = "Template for cluster worker nodes updated to limit stopped container lifespan"
+
+  for_each = local.launch_templates
+
+  name                   = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
+  description            = "Template for ${each.value.description_infix}cluster worker nodes updated to limit stopped container lifespan"
   ebs_optimized           = "false"
   image_id                = nonsensitive(aws_ssm_parameter.ecs_ami.value)
   update_default_version = true
   tags = {
-    "Name"            = "calcloud-hst-worker${local.environment}"
-    "calcloud-hst"    = "calcloud-hst-worker${local.environment}"
+    "Name"            = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
+    "calcloud-hst"    = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
     "stsci-poc-email" = var.stsci_poc_email
   }
   user_data               = base64encode(templatefile("${path.module}/user_data.sh", {}))
@@ -67,7 +86,7 @@ resource "aws_launch_template" "hstdp" {
     iops                  = lookup(var.lt_ebs_iops, local.environment, 0)
     # throughput is only valid for gp3, but it doesn't accept '0' as valid. null works, which is then set to 0
     throughput            = lookup(var.lt_ebs_throughput, local.environment, null)
-    volume_size           = 150
+    volume_size           = each.value.volume_size
     volume_type           = lookup(var.lt_ebs_type, local.environment, "gp2")
             }
   }
@@ -81,8 +100,8 @@ resource "aws_launch_template" "hstdp" {
   tag_specifications {
     resource_type = "instance"
     tags = {
-      "Name"            = "calcloud-hst-worker${local.environment}"
-      "calcloud-hst"    = "calcloud-hst-worker${local.environment}"
+      "Name"            = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
+      "calcloud-hst"    = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
       "stsci-poc-email" = var.stsci_poc_email
     }
   }
@@ -90,8 +109,8 @@ resource "aws_launch_template" "hstdp" {
   tag_specifications {
     resource_type = "volume"
     tags = {
-      "Name"            = "calcloud-hst-worker${local.environment}"
-      "calcloud-hst"    = "calcloud-hst-worker${local.environment}"
+      "Name"            = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
+      "calcloud-hst"    = "calcloud-hst-worker${each.value.name_suffix}${local.environment}"
       "stsci-poc-email" = var.stsci_poc_email
     }
   }
@@ -99,14 +118,14 @@ resource "aws_launch_template" "hstdp" {
 
 resource "aws_batch_job_queue" "batch_queue" {
   name = "calcloud-hst-queue-${local.ladder[count.index].name}${local.environment}"
-  count = 4
+  count = length(local.ladder)
   compute_environments = [aws_batch_compute_environment.compute_env[count.index].arn]
   priority = 10   # need to vectorize?
   state = "ENABLED"
 }
 
 resource "aws_batch_compute_environment" "compute_env" {
-  count = 4
+  count = length(local.ladder)
   compute_environment_name_prefix = "calcloud-hst-${local.ladder[count.index].name}${local.environment}"
   type = "MANAGED"
   service_role = nonsensitive(data.aws_ssm_parameter.batch_service_role.value)
@@ -125,7 +144,7 @@ resource "aws_batch_compute_environment" "compute_env" {
     desired_vcpus = local.ladder[count.index].ce_desired_vcpus
 
     launch_template {
-      launch_template_id = aws_launch_template.hstdp.id
+      launch_template_id = aws_launch_template.hstdp[local.ladder[count.index].lt_volume_size_key].id
       version = "$Latest"
     }
   }
@@ -142,7 +161,7 @@ resource "aws_batch_compute_environment" "compute_env" {
 
 resource "aws_batch_job_definition" "job_def" {
   name                 = "calcloud-jobdef-${local.ladder[count.index].name}${local.environment}"
-  count = 4
+  count = length(local.ladder)
   type                 = "container"
   container_properties = <<CONTAINER_PROPERTIES
   {

--- a/terraform/batch.tf
+++ b/terraform/batch.tf
@@ -203,11 +203,14 @@ resource "aws_s3_bucket" "calcloud" {
     "Name"            = "calcloud-processing${local.environment}"
     "stsci-poc-email" = var.stsci_poc_email
   }
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = "AES256"
-      }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "calcloud" {
+  bucket = "calcloud-processing${local.environment}"
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -43,9 +43,14 @@ awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backen
 cd ${CALCLOUD_BUILD_DIR}/terraform
 
 # must taint the compute env to be safe about launch template handling. see comments in batch.tf
-for i in {0..7}; do
+
+# In locals.tf, we define a local variable 'ladder' that is an array with one item for each compute environment.
+# When we change the length of the 'ladder' array, we need to change the LENGTH_LADDER variable here to match.
+LENGTH_LADDER=8
+for ((i=0; i<LENGTH_LADDER; i++)); do
     awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[$i]
 done
+
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.model_compute_env[0]
 awsudo $ADMIN_ARN terraform taint module.lambda_function_container_image.aws_lambda_function.this[0]
 

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -14,7 +14,7 @@ echo $aws_tfstate
 
 # get AMI id(s)
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-awsudo $ADMIN_ARN ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+awsudo $ADMIN_ARN aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
 ci_ami=`python3 parse_image_json.py STSCI-AMAZON-LINUX2023`
 ecs_ami=`python3 parse_image_json.py STSCI-EPH-ECS-AL2023`
 
@@ -43,11 +43,13 @@ awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backen
 cd ${CALCLOUD_BUILD_DIR}/terraform
 
 # must taint the compute env to be safe about launch template handling. see comments in batch.tf
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[0]
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[1]
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[2]
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[3]
+for i in {0..3}; do
+    awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[$i]
+done
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.model_compute_env[0]
+
+# This is the lambda for the prediction model. It is not routinely built because the code
+# contains create_package = false.  This causes the tain to fail with "Error: No such resource instance"
 awsudo $ADMIN_ARN terraform taint module.lambda_function_container_image.aws_lambda_function.this[0]
 
 # manual confirmation required

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -43,14 +43,17 @@ awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backen
 cd ${CALCLOUD_BUILD_DIR}/terraform
 
 # must taint the compute env to be safe about launch template handling. see comments in batch.tf
-for i in {0..3}; do
+for i in {0..7}; do
     awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[$i]
 done
 awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.model_compute_env[0]
-
-# This is the lambda for the prediction model. It is not routinely built because the code
-# contains create_package = false.  This causes the tain to fail with "Error: No such resource instance"
 awsudo $ADMIN_ARN terraform taint module.lambda_function_container_image.aws_lambda_function.this[0]
+
+# This can be removed after v0.4.49 is deployed to all environments.
+# We need to tell terraform we are moving aws_launch_template.hstdp -> aws_launch_template.hstdp["default"]
+if awsudo $ADMIN_ARN terraform state list | grep -q "aws_launch_template.hstdp$" ; then
+    awsudo $ADMIN_ARN terraform state mv aws_launch_template.hstdp 'aws_launch_template.hstdp[\"default\"]'
+fi
 
 # manual confirmation required
 awsudo $ADMIN_ARN terraform apply -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CSYS_VER}" -var "environment=${aws_env}" -var "ci_ami=${ci_ami}" -var "ecs_ami=${ecs_ami}" -var "full_base_image=${BASE_IMAGE_TAG}" -var "ami_rotation_base_image=${AMIROTATION_DOCKER_IMAGE}"

--- a/terraform/deploy_ami_rotate.sh
+++ b/terraform/deploy_ami_rotate.sh
@@ -75,7 +75,7 @@ echo $aws_tfstate
 
 # get AMI id
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-awsudo $ADMIN_ARN ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+awsudo $ADMIN_ARN aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
 ci_ami=`python3 parse_image_json.py STSCI-AMAZON-LINUX2023`
 ecs_ami=`python3 parse_image_json.py STSCI-EPH-ECS-AL2023`
 

--- a/terraform/deploy_checkout_repos.sh
+++ b/terraform/deploy_checkout_repos.sh
@@ -5,7 +5,7 @@ source deploy_vars.sh
 cwd=`pwd`
 # setting up the calcloud source dir if it needs downloaded
 # equivalent to "if len($var) == 0"
-if [ -z "${CALCLOUD_BUILD_DIR}" ]
+if [ -z "${CALCLOUD_BUILD_DIR}" -o ! -d "${CALCLOUD_BUILD_DIR}" ]
 then
     mkdir -p $TMP_INSTALL_DIR
     CALCLOUD_BUILD_DIR="${TMP_INSTALL_DIR}/calcloud"
@@ -28,7 +28,7 @@ fi
 
 # setting up the caldp source dir if it needs downloaded
 # equivalent to "if len($var) == 0"
-if [ -z "${CALDP_BUILD_DIR}" ]
+if [ -z "${CALDP_BUILD_DIR}" -o ! -d "${CALDP_BUILD_DIR}" ]
 then
     mkdir -p $TMP_INSTALL_DIR
     CALDP_BUILD_DIR="${TMP_INSTALL_DIR}/caldp"

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -xu
-export CALCLOUD_VER="v0.4.48"
+export CALCLOUD_VER="v0.4.49-rc1"
 export CALDP_VER="v0.2.30"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:2026.2.1.7-arcticdrizzle-py312"
 

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -xu
-export CALCLOUD_VER="v0.4.49-rc2"
+export CALCLOUD_VER="v0.4.49-rc3"
 export CALDP_VER="v0.2.30"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:2026.2.1.7-arcticdrizzle-py312"
 

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -xu
-export CALCLOUD_VER="v0.4.49-rc1"
+export CALCLOUD_VER="v0.4.49-rc2"
 export CALDP_VER="v0.2.30"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:2026.2.1.7-arcticdrizzle-py312"
 

--- a/terraform/lambda_common.tf
+++ b/terraform/lambda_common.tf
@@ -5,14 +5,17 @@ resource "aws_s3_bucket" "calcloud_lambda_envs" {
     "Name"            = "calcloud-lambda-envs${local.environment}"
     "stsci-poc-email" = var.stsci_poc_email
   }
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = "AES256"
-      }
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "calcloud_lambda_envs" {
+  bucket = "calcloud-lambda-envs${local.environment}"
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
-  force_destroy = true
 }
 
 # ssl requests policy

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -32,6 +32,7 @@ locals {
 
                 jd_memory = 2*(1024-128),
                 jd_vcpu = 1,
+                lt_volume_size_key = "default",
               },
               { # -------------------------------------------------------------------
                 name : "08g",
@@ -47,6 +48,7 @@ locals {
 
                 jd_memory = 8*(1024-128),
                 jd_vcpu = 2,
+                lt_volume_size_key = "default",
               },
               { # -------------------------------------------------------------------
                 name : "16g",
@@ -62,6 +64,7 @@ locals {
 
                 jd_memory = 16*(1024-128),
                 jd_vcpu = 2,
+                lt_volume_size_key = "default",
               },
               { # -------------------------------------------------------------------
                 name : "64g",
@@ -77,6 +80,70 @@ locals {
 
                 jd_memory = 64*(1024-128),
                 jd_vcpu = 8,
+                lt_volume_size_key = "default",
+              },
+                            { # -------------------------------------------------------------------
+                name : "02g-large-volume",
+
+                # 2g job def -> 2g queue -> 2g compute env
+                ce_instance_type = [
+                    "c5a.2xlarge",    #  8 cores,  16G    $0.308 / hr, 8 concurrent jobs
+                 ],
+                ce_min_vcpus : 0,
+                ce_max_vcpus : lookup(var.ce_max_vcpu, local.environment, 64),
+                ce_desired_vcpus : 0,
+
+                jd_memory = 2*(1024-128),
+                jd_vcpu = 1,
+                lt_volume_size_key = "large-volume",
+              },
+              { # -------------------------------------------------------------------
+                name : "08g-large-volume",
+
+                # 8g job def -> 8g queue -> 8g compute env
+                ce_instance_type = [
+                    "m5a.2xlarge",    #  8 cores, 32G     $0.344 / hr, 4 concurrent jobs
+                ],
+
+                ce_min_vcpus : 0,
+                ce_max_vcpus : lookup(var.ce_max_vcpu, local.environment, 64),
+                ce_desired_vcpus : 0,
+
+                jd_memory = 8*(1024-128),
+                jd_vcpu = 2,
+                lt_volume_size_key = "large-volume",
+              },
+              { # -------------------------------------------------------------------
+                name : "16g-large-volume",
+
+                # 16g job def -> 16g queue -> 16g compute env
+                ce_instance_type = [
+                    "r5a.xlarge",    #  4 cores,  32G    $0.226 / hr, 2 concurrent jobs
+                ],
+
+                ce_min_vcpus : 0,
+                ce_max_vcpus : lookup(var.ce_max_vcpu, local.environment, 64),
+                ce_desired_vcpus : 0,
+
+                jd_memory = 16*(1024-128),
+                jd_vcpu = 2,
+                lt_volume_size_key = "large-volume",
+              },
+              { # -------------------------------------------------------------------
+                name : "64g-large-volume",
+
+                # 64g job def -> 64g queue -> 64g compute env (r series or something else, enough memory to fit ~2 jobs per ec2)
+                ce_instance_type = [
+                    "r5a.2xlarge",    #  8 cores, 64G   $0.452 / hr, 1 concurrent job
+                ],
+
+                ce_min_vcpus : 0,
+                ce_max_vcpus : lookup(var.ce_max_vcpu, local.environment, 64),
+                ce_desired_vcpus : 0,
+
+                jd_memory = 64*(1024-128),
+                jd_vcpu = 8,
+                lt_volume_size_key = "large-volume",
               },
        ]
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -18,6 +18,9 @@ locals {
        job_queues = join(",", aws_batch_job_queue.batch_queue[*].name)   # for env vars
 
        # Reserving 128M/1024M for ECS overheads
+
+       # If you change the length of the ladder array, you must increase LENGTH_LADDER in deploy.sh to match.
+       # See LENGTH_LADDER in deploy.sh.
        ladder = [
               { # -------------------------------------------------------------------
                 name : "02g",

--- a/terraform/model_training.tf
+++ b/terraform/model_training.tf
@@ -26,7 +26,7 @@ resource "aws_batch_compute_environment" "model_compute_env" {
     desired_vcpus = 0
 
     launch_template {
-      launch_template_id = aws_launch_template.hstdp.id
+      launch_template_id = aws_launch_template.hstdp["default"].id
       version = "$Latest"
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,19 +25,36 @@ sys.path.append(str(Path(__file__).resolve().parent.parent / "lambda/broadcast")
 
 EVENT_DIR = str(Path(__file__).resolve().parent / "artifacts/events")
 
-JOBDEFINITIONS = ["calcloud-jobdef-2g", "calcloud-jobdef-2g-large-volume",
-                  "calcloud-jobdef-8g", "calcloud-jobdef-8g-large-volume",
-                  "calcloud_jobdef-16g", "calcloud_jobdef-16g-large-volume",
-                  "calcloud-jobdef-64g", "calcloud-jobdef-64g-large-volume"
-                  ]
-CENVIRONMENTS = ["calcloud-cenv-2g", "calcloud-cenv-2g-large-volume",
-                 "calcloud-cenv-8g", "calcloud-cenv-8g-large-volume",
-                 "calcloud-cenv-16g", "calcloud-cenv-16g-large-volume",
-                 "calcloud-cenv-64g", "calcloud-cenv-64g-large-volume",]
-JOBQUEUES = ["calcloud-jobqueue-2g", "calcloud-jobqueue-2g-large-volume",
-             "calcloud-jobqueue-8g", "calcloud-jobqueue-8g-large-volume",
-             "calcloud-jobqueue-16g", "calcloud-jobqueue-16g-large-volume",
-             "calcloud-jobqueue-64g", "calcloud-jobqueue-64g-large-volume"]
+JOBDEFINITIONS = [
+    "calcloud-jobdef-2g",
+    "calcloud-jobdef-2g-large-volume",
+    "calcloud-jobdef-8g",
+    "calcloud-jobdef-8g-large-volume",
+    "calcloud_jobdef-16g",
+    "calcloud_jobdef-16g-large-volume",
+    "calcloud-jobdef-64g",
+    "calcloud-jobdef-64g-large-volume",
+]
+CENVIRONMENTS = [
+    "calcloud-cenv-2g",
+    "calcloud-cenv-2g-large-volume",
+    "calcloud-cenv-8g",
+    "calcloud-cenv-8g-large-volume",
+    "calcloud-cenv-16g",
+    "calcloud-cenv-16g-large-volume",
+    "calcloud-cenv-64g",
+    "calcloud-cenv-64g-large-volume",
+]
+JOBQUEUES = [
+    "calcloud-jobqueue-2g",
+    "calcloud-jobqueue-2g-large-volume",
+    "calcloud-jobqueue-8g",
+    "calcloud-jobqueue-8g-large-volume",
+    "calcloud-jobqueue-16g",
+    "calcloud-jobqueue-16g-large-volume",
+    "calcloud-jobqueue-64g",
+    "calcloud-jobqueue-64g-large-volume",
+]
 BUCKET = "calcloud-processing-moto"
 TEST_DATASET_NAMES = [
     "ieloc4yzq",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,19 @@ sys.path.append(str(Path(__file__).resolve().parent.parent / "lambda/broadcast")
 
 EVENT_DIR = str(Path(__file__).resolve().parent / "artifacts/events")
 
-JOBDEFINITIONS = ["calcloud-jobdef-2g", "calcloud-jobdef-8g", "calcloud_jobdef-16g", "calcloud-jobdef-64g"]
-CENVIRONMENTS = ["calcloud-cenv-2g", "calcloud-cenv-8g", "calcloud-cenv-16g", "calcloud-cenv-64g"]
-JOBQUEUES = ["calcloud-jobqueue-2g", "calcloud-jobqueue-8g", "calcloud-jobqueue-16g", "calcloud-jobqueue-64g"]
+JOBDEFINITIONS = ["calcloud-jobdef-2g", "calcloud-jobdef-2g-large-volume",
+                  "calcloud-jobdef-8g", "calcloud-jobdef-8g-large-volume",
+                  "calcloud_jobdef-16g", "calcloud_jobdef-16g-large-volume",
+                  "calcloud-jobdef-64g", "calcloud-jobdef-64g-large-volume"
+                  ]
+CENVIRONMENTS = ["calcloud-cenv-2g", "calcloud-cenv-2g-large-volume",
+                 "calcloud-cenv-8g", "calcloud-cenv-8g-large-volume",
+                 "calcloud-cenv-16g", "calcloud-cenv-16g-large-volume",
+                 "calcloud-cenv-64g", "calcloud-cenv-64g-large-volume",]
+JOBQUEUES = ["calcloud-jobqueue-2g", "calcloud-jobqueue-2g-large-volume",
+             "calcloud-jobqueue-8g", "calcloud-jobqueue-8g-large-volume",
+             "calcloud-jobqueue-16g", "calcloud-jobqueue-16g-large-volume",
+             "calcloud-jobqueue-64g", "calcloud-jobqueue-64g-large-volume"]
 BUCKET = "calcloud-processing-moto"
 TEST_DATASET_NAMES = [
     "ieloc4yzq",


### PR DESCRIPTION
Previously, the terraform scripts:
* created 1 launch template called hstsdp with a disk size of 150GB.
* used a variable called local.ladder with 4 rungs - 02g, 08g, 16g, 64g
* created 4 job queues, compute environments, and job definitions - one each for each of the 4 local.ladder rungs

I have modified the scripts to:
* create 2 launch templates: hstdp["default"] with a disk size of 150GB and hstdp["large-volume"] with a disk size of 300GB.
* use a local.ladder var with 8 rungs - 02g, 08g, 16g, 64g and 02g-large-volume, 08g-large-volume, 16g-large-volume, 64g-large-volume
* create 8 job queues, compute environments, and job definitions - one each for each of the local.ladder rungs

In addition, 
* I modified multiple places where we explicitly used to iterate over 4 rungs of local.ladder to now use iterate over length(local.ladder) rungs.
* In plan.py, I modified functions to use "default" AWS resources for ipppssoots and svms, and "large-volume" resources for mvms.
* I updated the tests to include the new queues, compute environments, and definitions.

I have run this with tests 08106 and 08107 and observed the ipppssoots and svms are routed to default volume size EC2 instances, and mvms are routed to large-volume EC2 instances. 
https://jira.stsci.edu/browse/CALCLOUD-462?focusedId=1037304&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1037304

