### PR TITLE
CALCLOUD-462 Change version to CALCLOUD-462

### DIFF
--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -xu
-export CALCLOUD_VER="v0.4.49-rc3"
+export CALCLOUD_VER="CALCLOUD-462"
 export CALDP_VER="v0.2.30"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:2026.2.1.7-arcticdrizzle-py312"
 


### PR DESCRIPTION
This PR just changes the version tag from a release candidate (which as you pointed out does not make sense) to a jira-key.