### PR TITLE
CALCLOUD-475 Bump version to CALCLOUD-475

### DIFF
--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -xu
-export CALCLOUD_VER="CALCLOUD-475-9"
+export CALCLOUD_VER="CALCLOUD-475"
 export CALDP_VER="v0.2.30"
 export CAL_BASE_IMAGE="stsci/hst-pipeline:2026.2.1.7-arcticdrizzle-py312"
 


### PR DESCRIPTION
This PR only bumps the version to CALCLOUD-475 so that I can re-build the docker containers with the few minor changes from the review.