### PR TITLE
CALCLOUD-472 Replace awsudo with AWS_PROFILE

### DIFF
--- a/ami_rotation/ami_rotation_userdata.sh
+++ b/ami_rotation/ami_rotation_userdata.sh
@@ -109,16 +109,25 @@ yum install python3.11-pip -y -q
 sudo -i -u ec2-user bash << EOF
 mkdir ~/bin ~/tmp
 cd ~/tmp
-curl -s -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
-bash ~/.nvm/nvm.sh
 source ~/.bashrc
-nvm install 16
-npm config set registry http://registry.npmjs.org/
-npm config set cafile /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-npm install -g awsudo@1.5.0
 python3.11 -m pip install -q --upgrade pip && python3.11 -m pip install boto3 -q
 cd ~
 rm -rf ~/tmp
+EOF
+
+# Set up the AWS Profile for the admin role.
+cat << EOF > /home/ec2-user/.aws/config
+[profile hst_reprocessing_admin_role]
+region = us-east-1
+role_arn = ${admin_arn}
+credential_source = Ec2InstanceMetadata
+
+# This profile is required for ecr describe-image-scan-findings because
+# that command cannot be called cross-account.
+[profile hst-repro-cross-account-ECR-access]
+region = us-east-1
+role_arn = arn:aws:iam::378083651696:role/hst-repro-cross-account-ECR-access
+source_profile = hst_reprocessing_admin_role
 EOF
 
 chown -R ec2-user:ec2-user /home/ec2-user/

--- a/iac/codebuild/Dockerfile
+++ b/iac/codebuild/Dockerfile
@@ -28,14 +28,6 @@ RUN set -ex \
     && yum install tar wget python3.11 which -y \
     && yum install python3.11-pip -y
 
-RUN yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
-RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
-
-RUN npm install n -g
-
-RUN npm config set registry http://registry.npmjs.org/ && \
-    npm install -g awsudo@1.5.0
-
 RUN pip3.11 install awscli
 
 COPY calcloud_checkout.sh /root/

--- a/scripts/check_batch_jobs.py
+++ b/scripts/check_batch_jobs.py
@@ -15,7 +15,7 @@ cmd = "rm ./*.json"
 os.system(cmd)
 
 # dump the jobQueues to json
-cmd = "awsudo $ADMIN_ARN aws batch describe-job-queues > queues.json"
+cmd = "AWS_PROFILE=hst_reprocessing_admin_role aws batch describe-job-queues > queues.json"
 os.system(cmd)
 
 with open("./queues.json", "r") as f:
@@ -24,7 +24,7 @@ with open("./queues.json", "r") as f:
 for queue in queues["jobQueues"]:
     name = queue["jobQueueName"]
     for status in statuses:
-        cmd = f"awsudo $ADMIN_ARN aws batch list-jobs --job-queue {name} --job-status {status} > {name}_{status}.json"
+        cmd = f"AWS_PROFILE=hst_reprocessing_admin_role aws batch list-jobs --job-queue {name} --job-status {status} > {name}_{status}.json"
         os.system(cmd)
         with open(f"{name}_{status}.json", "r") as f:
             jobs = json.load(f)

--- a/terraform/ami-rotation-image-scan.py
+++ b/terraform/ami-rotation-image-scan.py
@@ -36,7 +36,7 @@ KEEP_LEVELS = {
 FAIL_LEVELS = ["CRITCAL", "HIGH"]
 
 
-def run(cmd, cwd="."):
+def run(cmd, cwd=".", env=None):
     result = subprocess.run(
         cmd.split(),
         stdout=subprocess.PIPE,
@@ -44,6 +44,7 @@ def run(cmd, cwd="."):
         text=True,
         check=True,
         cwd=cwd,
+        env=env,
     )  # maybe succeeds
     return result.stdout
 
@@ -52,7 +53,6 @@ def _get_scan_results(image_digest, image_tag):
     """Issue an AWS command to dump the ECR scan results as JSON, load the
     JSON,  and return the resulting dict.
     """
-    admin_arn = os.environ["ADMIN_ARN"]
     image_repo = os.environ["IMAGE_REPO"]
     ecr_account_to_use = os.environ["ECR_ACCOUNT_ID"]
 
@@ -65,12 +65,15 @@ def _get_scan_results(image_digest, image_tag):
         file=sys.stderr,
     )
 
+    # This uses hst-repro-cross-account-ECR-access which is a role in the ECR account.
+    # You cannot run describe-image-scan-findings cross account, you have to use a role in the other account.
     scan_results = run(
-        f"awsudo -d 3600 {admin_arn}  aws ecr describe-image-scan-findings "
+        f"aws ecr describe-image-scan-findings "
         f"--no-paginate "
         f"--registry-id {ecr_account_to_use} "
         f"--repository-name {image_repo} "
-        f"--image-id {image_id_arg}"
+        f"--image-id {image_id_arg}",
+        env=dict(os.environ) | {"AWS_PROFILE": "hst-repro-cross-account-ECR-access"},
     )
 
     # print("Scan Results")

--- a/terraform/deploy.sh
+++ b/terraform/deploy.sh
@@ -7,14 +7,14 @@ source deploy_vars.sh
 source deploy_checkout_repos.sh
 
 # the tf state bucket name
-aws_tfstate_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
+aws_tfstate_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
 aws_tfstate=${aws_tfstate_response##*:}
 aws_tfstate=`echo $aws_tfstate | tr -d '",'`
 echo $aws_tfstate
 
 # get AMI id(s)
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-awsudo $ADMIN_ARN aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+AWS_PROFILE=hst_reprocessing_admin_role aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
 ci_ami=`python3.11 parse_image_json.py STSCI-AMAZON-LINUX2023`
 ecs_ami=`python3.11 parse_image_json.py STSCI-EPH-ECS-AL2023`
 
@@ -37,7 +37,7 @@ env | sort
 # initial terraform setup
 cd ${CALCLOUD_BUILD_DIR}/terraform
 
-awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
+AWS_PROFILE=hst_reprocessing_admin_role terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
 
 #### PRIMARY TERRAFORM BUILD #####
 cd ${CALCLOUD_BUILD_DIR}/terraform
@@ -48,19 +48,19 @@ cd ${CALCLOUD_BUILD_DIR}/terraform
 # When we change the length of the 'ladder' array, we need to change the LENGTH_LADDER variable here to match.
 LENGTH_LADDER=8
 for ((i=0; i<LENGTH_LADDER; i++)); do
-    awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[$i]
+    AWS_PROFILE=hst_reprocessing_admin_role terraform taint aws_batch_compute_environment.compute_env[$i]
 done
 
-awsudo $ADMIN_ARN terraform taint module.lambda_function_container_image.aws_lambda_function.this[0]
+AWS_PROFILE=hst_reprocessing_admin_role terraform taint module.lambda_function_container_image.aws_lambda_function.this[0]
 
 # This can be removed after v0.4.49 is deployed to all environments.
 # We need to tell terraform we are moving aws_launch_template.hstdp -> aws_launch_template.hstdp["default"]
-if awsudo $ADMIN_ARN terraform state list | grep -q "aws_launch_template.hstdp$" ; then
-    awsudo $ADMIN_ARN terraform state mv aws_launch_template.hstdp 'aws_launch_template.hstdp[\"default\"]'
+if AWS_PROFILE=hst_reprocessing_admin_role terraform state list | grep -q "aws_launch_template.hstdp$" ; then
+    AWS_PROFILE=hst_reprocessing_admin_role terraform state mv aws_launch_template.hstdp 'aws_launch_template.hstdp["default"]'
 fi
 
 # manual confirmation required
-awsudo $ADMIN_ARN terraform apply -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CSYS_VER}" -var "environment=${aws_env}" -var "ci_ami=${ci_ami}" -var "ecs_ami=${ecs_ami}" -var "full_base_image=${BASE_IMAGE_TAG}" -var "ami_rotation_base_image=${AMIROTATION_DOCKER_IMAGE}"
+AWS_PROFILE=hst_reprocessing_admin_role terraform apply -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CSYS_VER}" -var "environment=${aws_env}" -var "ci_ami=${ci_ami}" -var "ecs_ami=${ecs_ami}" -var "full_base_image=${BASE_IMAGE_TAG}" -var "ami_rotation_base_image=${AMIROTATION_DOCKER_IMAGE}"
 
 # brief testing indicates that terraform apply exits with 0 status only if you say yes and the apply succeeds
 apply_status=$?
@@ -71,25 +71,25 @@ fi
 
 # make sure needed prefixes exist in primary s3 bucket
 # pulls the bucket name in from a tag called Name
-bucket_url_response=`awsudo $ADMIN_ARN terraform state show aws_s3_bucket.calcloud | grep "Name"`
+bucket_url_response=`AWS_PROFILE=hst_reprocessing_admin_role terraform state show aws_s3_bucket.calcloud | grep "Name"`
 bucket_url=${bucket_url_response##*=}
 # removes double quotes from variable
 bucket_url=`echo $bucket_url | tr -d '"'`
 
 # get the crds context
-crds_response=`awsudo $ADMIN_ARN terraform output | grep "crds"`
+crds_response=`AWS_PROFILE=hst_reprocessing_admin_role terraform output | grep "crds"`
 crds_context=${crds_response##*=}
 crds_context=`echo $crds_context | tr -d '"'`
 
-awsudo $ADMIN_ARN aws s3 rm s3://${bucket_url}/crds_env_vars/ --recursive
+AWS_PROFILE=hst_reprocessing_admin_role aws s3 rm s3://${bucket_url}/crds_env_vars/ --recursive
 
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key messages/
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key inputs/
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key outputs/
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key control/
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key blackboard/
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key crds_env_vars/
-awsudo $ADMIN_ARN aws s3api put-object --bucket $bucket_url --key crds_env_vars/${crds_context}
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key messages/
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key inputs/
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key outputs/
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key control/
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key blackboard/
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key crds_env_vars/
+AWS_PROFILE=hst_reprocessing_admin_role aws s3api put-object --bucket $bucket_url --key crds_env_vars/${crds_context}
 
 # tag images as in-use by this environment
 cd $CALCLOUD_BUILD_DIR/terraform

--- a/terraform/deploy_ami_rotate.sh
+++ b/terraform/deploy_ami_rotate.sh
@@ -4,15 +4,15 @@
 aws_env=${aws_env:-""}
 
 # get the versions from ssm params
-calcloud_ver_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/tf/env/awsysver-${aws_env}" | grep "Value"`
+calcloud_ver_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/tf/env/awsysver-${aws_env}" | grep "Value"`
 CALCLOUD_VER=${calcloud_ver_response##*:}
 CALCLOUD_VER=`echo $CALCLOUD_VER | tr -d '",'`
 
-caldp_ver_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/tf/env/awsdpver-${aws_env}" | grep "Value"`
+caldp_ver_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/tf/env/awsdpver-${aws_env}" | grep "Value"`
 CALDP_VER=${caldp_ver_response##*:}
 CALDP_VER=`echo $CALDP_VER | tr -d '",'`
 
-csys_ver_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/tf/env/csys_ver-${aws_env}" | grep "Value"`
+csys_ver_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/tf/env/csys_ver-${aws_env}" | grep "Value"`
 CSYS_VER=${csys_ver_response##*:}
 CSYS_VER=`echo $CSYS_VER | tr -d '",'`
 
@@ -62,20 +62,20 @@ fi
 # the env, i.e. sb,dev,test,prod
 if [ -z "${aws_env}" ]
 then
-    aws_env_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "environment" | grep "Value"`
+    aws_env_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "environment" | grep "Value"`
     aws_env=${aws_env_response##*:}
     aws_env=`echo $aws_env | tr -d '",'`
 fi
 
 # the tf state bucket name
-aws_tfstate_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
+aws_tfstate_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/s3/tfstate" | grep "Value"`
 aws_tfstate=${aws_tfstate_response##*:}
 aws_tfstate=`echo $aws_tfstate | tr -d '",'`
 echo $aws_tfstate
 
 # get AMI id
 cd $CALCLOUD_BUILD_DIR/ami_rotation
-awsudo $ADMIN_ARN aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
+AWS_PROFILE=hst_reprocessing_admin_role aws ec2 describe-images --region us-east-1 --executable-users self --output json > images.json
 ci_ami=`python3.11 parse_image_json.py STSCI-AMAZON-LINUX2023`
 ecs_ami=`python3.11 parse_image_json.py STSCI-EPH-ECS-AL2023`
 
@@ -97,22 +97,22 @@ fi
 cd ${CALCLOUD_BUILD_DIR}/terraform
 
 # terraform init and s3 state backend config
-awsudo $ADMIN_ARN terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
+AWS_PROFILE=hst_reprocessing_admin_role terraform init -backend-config="bucket=${aws_tfstate}" -backend-config="key=calcloud/${aws_env}.tfstate" -backend-config="region=us-east-1"
 
 # in order to rotate the ami, requires a new version of the launch template and the associated compute environments
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[0]
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[1]
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[2]
-awsudo $ADMIN_ARN terraform taint aws_batch_compute_environment.compute_env[3]
+AWS_PROFILE=hst_reprocessing_admin_role terraform taint aws_batch_compute_environment.compute_env[0]
+AWS_PROFILE=hst_reprocessing_admin_role terraform taint aws_batch_compute_environment.compute_env[1]
+AWS_PROFILE=hst_reprocessing_admin_role terraform taint aws_batch_compute_environment.compute_env[2]
+AWS_PROFILE=hst_reprocessing_admin_role terraform taint aws_batch_compute_environment.compute_env[3]
 
-awsudo $ADMIN_ARN terraform plan -no-color -var "environment=${aws_env}" -out ami_rotate.out \
+AWS_PROFILE=hst_reprocessing_admin_role terraform plan -no-color -var "environment=${aws_env}" -out ami_rotate.out \
     -target aws_batch_compute_environment.compute_env \
     -target aws_batch_job_queue.batch_queue \
     -target aws_launch_template.hstdp \
     -target aws_launch_template.ami_rotation \
     -var "awsysver=${CALCLOUD_VER}" -var "awsdpver=${CALDP_VER}" -var "csys_ver=${CSYS_VER}" -var "environment=${aws_env}" -var "ci_ami=${ci_ami}" -var "ecs_ami=${ecs_ami}"
 
-awsudo $ADMIN_ARN terraform apply -no-color "ami_rotate.out"
+AWS_PROFILE=hst_reprocessing_admin_role terraform apply -no-color "ami_rotate.out"
 
 cd $HOME
 rm -rf $TMP_INSTALL_DIR

--- a/terraform/deploy_ami_rotation_codebuild_image.sh
+++ b/terraform/deploy_ami_rotation_codebuild_image.sh
@@ -20,7 +20,7 @@ if [[ $amirotation_docker_build_status -ne 0 ]]; then
 fi
 
 # need to "log in" to ecr to push or pull the images
-awsudo $ADMIN_ARN aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo_url
+AWS_PROFILE=hst_reprocessing_admin_role aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo_url
 
 echo Pushing ${AMIROTATION_DOCKER_IMAGE_UNSCANNED}
 docker push ${AMIROTATION_DOCKER_IMAGE_UNSCANNED}

--- a/terraform/deploy_docker_builds.sh
+++ b/terraform/deploy_docker_builds.sh
@@ -44,7 +44,7 @@ cd ${CALCLOUD_BUILD_DIR}/terraform
 source deploy_ami_rotation_codebuild_image.sh # build, scan, and tag AMIROTATION image
 
 # need to "log in" to ecr to push or pull the images
-awsudo $ADMIN_ARN aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo_url
+AWS_PROFILE=hst_reprocessing_admin_role aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $repo_url
 
 echo Pushing ${PREDICT_DOCKER_IMAGE}
 docker push ${PREDICT_DOCKER_IMAGE}

--- a/terraform/deploy_ecr_image_delete.sh
+++ b/terraform/deploy_ecr_image_delete.sh
@@ -15,7 +15,7 @@ if [[ "$#" == "0" ]]; then
     exit 2
 fi
 
-SSM_PARAM=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/ecr/SharedServices" --query "Parameter.Value" --output text`
+SSM_PARAM=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/ecr/SharedServices" --query "Parameter.Value" --output text`
 ECR_ACCOUNT_ID=`echo $SSM_PARAM | cut -d '.' -f1`    # 123456789123
 IMAGE_REPO=`echo $SSM_PARAM | cut -d '/' -f2`        # ecr-repo-name
 
@@ -25,5 +25,5 @@ for image in ${IMAGES}; do
     else
 	    QUALIFIER=imageTag
     fi
-    awsudo ${ADMIN_ARN} aws ecr batch-delete-image --registry-id ${ECR_ACCOUNT_ID} --repository-name ${IMAGE_REPO} --image-ids ${QUALIFIER}=${image}
+    AWS_PROFILE=hst_reprocessing_admin_role aws ecr batch-delete-image --registry-id ${ECR_ACCOUNT_ID} --repository-name ${IMAGE_REPO} --image-ids ${QUALIFIER}=${image}
 done

--- a/terraform/deploy_existing_imageTag_check.sh
+++ b/terraform/deploy_existing_imageTag_check.sh
@@ -17,7 +17,7 @@ anyImage="0"
 for imageTag in ${TAGS}; do
     # describe images returns exit code 1 if the image does not exist
     # batch-get-image does NOT
-    awsudo ${ADMIN_ARN} aws ecr describe-images --registry-id ${ECR_ACCOUNT_ID} --repository-name ${IMAGE_REPO} --image-ids imageTag=${imageTag}
+    AWS_PROFILE=hst_reprocessing_admin_role aws ecr describe-images --registry-id ${ECR_ACCOUNT_ID} --repository-name ${IMAGE_REPO} --image-ids imageTag=${imageTag}
     tagNotExist=$?
 
     if [[ $tagNotExist -eq 0 ]]; then

--- a/terraform/deploy_image_promote.sh
+++ b/terraform/deploy_image_promote.sh
@@ -30,12 +30,9 @@ while [ "$1" != "" ]; do
             exit
 	    ;;
 	* )
-	    break  # Default case: no more options so break out and leave remaining args unshifted 
+	    break  # Default case: no more options so break out and leave remaining args unshifted
     esac
     shift
 done
 
-# This greatly saddens me but this subprogram is the only way to get this working because of two reasons
-# awsudo seems to have a bug where it will unquote a quoted variable when it translates the command
-# the ecr tag updating process is so finnicky that trying to modify it in any way breaks it
-registry=$registry repo=$repo old_tag=$old_tag new_tag=$1 awsudo $ADMIN_ARN ./deploy_ecr_apply_tag.sh
+registry=$registry repo=$repo old_tag=$old_tag new_tag=$1 AWS_PROFILE=hst_reprocessing_admin_role ./deploy_ecr_apply_tag.sh

--- a/terraform/deploy_print_central_images.sh
+++ b/terraform/deploy_print_central_images.sh
@@ -3,4 +3,4 @@
 # simple convenience script for printing all images in the central ECR
 source deploy_vars.sh
 
-awsudo $ADMIN_ARN aws ecr list-images --registry-id $ECR_ACCOUNT_ID --repository-name $IMAGE_REPO 
+AWS_PROFILE=hst_reprocessing_admin_role aws ecr list-images --registry-id $ECR_ACCOUNT_ID --repository-name $IMAGE_REPO 

--- a/terraform/deploy_vars.sh
+++ b/terraform/deploy_vars.sh
@@ -24,7 +24,7 @@ export TF_VAR_account_id=$ACCOUNT_ID
 aws_env=${aws_env:-""}
 if [ -z "${aws_env}" ]
 then
-    aws_env_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "environment" | grep "Value"`
+    aws_env_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "environment" | grep "Value"`
     aws_env=${aws_env_response##*:}
     aws_env=`echo $aws_env | tr -d '",'`
 fi
@@ -34,7 +34,7 @@ export aws_env=${aws_env}
 repo_url=${repo_url:-""}
 if [ -z "${repo_url}" ]
 then
-    repo_url_response=`awsudo $ADMIN_ARN aws ssm get-parameter --name "/ecr/SharedServices" | grep "Value"`
+    repo_url_response=`AWS_PROFILE=hst_reprocessing_admin_role aws ssm get-parameter --name "/ecr/SharedServices" | grep "Value"`
     repo_url=${repo_url_response##*:}
     repo_url=`echo $repo_url | tr -d '",'`
 fi


### PR DESCRIPTION
This change removes awsudo everywhere and replaces it with AWS_PROFILE.

awsudo uses a Node.js package that has not been updated since 2024: https://github.com/meltwater/awsudo.
It uses Node.js 16, which was last updated in 2023.   Node.js 16 is flagged by the vulnerability scanner in AWS, and we should remove it.

AWS_PROFILE provides a more robust and standardized solution.

awsudo is used on the ci-node and the ami-rotation node, and nowhere else.  It is not used in any of the AWS lambda or in the batch containers.

I have verified that AWS_PROFILE works correctly all places the the ci-node uses it.  I have also made changes for the ami-rotation node.  I have not verified the ami-rotation changes, because the ami-rotation node is not currently working.  However, when I fix ami-rotation, I will verify that AWS_PROFILE is working as expected there as well.

